### PR TITLE
feat: first-run setup wizard with onboarding gate

### DIFF
--- a/public/css/tailwind.src.css
+++ b/public/css/tailwind.src.css
@@ -19,6 +19,13 @@
   .pill { @apply inline-flex items-center gap-1 text-xs font-semibold px-2.5 py-0.5 rounded-full; }
   .pill-ok { @apply bg-sage-soft/20 text-sage; }
   .pill-over { @apply bg-clay-soft/20 text-clay; }
+  .label-caps { @apply text-xs font-semibold uppercase tracking-wide; }
+  .step-indicator { @apply flex flex-wrap gap-x-4 gap-y-2 my-3; }
+  .step { @apply flex items-center gap-2 text-sm text-ink-mut; }
+  .step-no { @apply w-6 h-6 rounded-full bg-line text-ink-mut text-xs font-semibold flex items-center justify-center; }
+  .step-active { @apply text-ink font-semibold; }
+  .step-active .step-no { @apply bg-sage text-white; }
+  .step-done .step-no { @apply bg-sage-soft text-white; }
   .field { @apply flex flex-col gap-1 text-sm; }
   .field > span { @apply text-xs font-semibold uppercase tracking-wide text-ink-mut; }
   .field input, .field select { @apply rounded border border-line bg-card px-3 py-2 text-ink focus:outline-none focus:ring-2 focus:ring-sage; }

--- a/public/js/budget.js
+++ b/public/js/budget.js
@@ -1,0 +1,19 @@
+import { formatBRL } from './format.js';
+
+// Pure budget-model helpers shared by the Settings page and the setup wizard.
+// Kept free of DOM side-effects so either page can import them safely.
+
+export function ceilingText(income, fixed, goal) {
+  return `Healthy ceiling ${formatBRL(income - fixed - goal)}`;
+}
+
+export function renderLimitRows(cats, byCat) {
+  return cats.filter(c => c.active).map(c => `
+    <tr class="border-b border-line">
+      <td class="py-2">${c.name}</td>
+      <td class="py-2 text-right">
+        <input type="number" step="0.01" data-cat="${c.id}" value="${(byCat.get(c.id) || 0) / 100}"
+          class="w-32 rounded border border-line bg-card px-2 py-1 text-right font-mono" />
+      </td>
+    </tr>`).join('');
+}

--- a/public/js/chrome.js
+++ b/public/js/chrome.js
@@ -22,7 +22,24 @@ export function renderNav(active) {
     <nav class="bottom-nav">${bottomLinks}</nav>`;
 }
 
+// First-run guard: send the user to the setup wizard until onboarding is done.
+// Tolerant of failures — a flaky check must never lock the user out of the app.
+export async function enforceOnboarding(fetchFn, loc) {
+  if (loc.pathname === '/setup.html') return;
+  try {
+    const res = await fetchFn('/api/onboarding');
+    if (!res.ok) return;
+    const { complete } = await res.json();
+    if (!complete) loc.replace('/setup.html');
+  } catch {
+    /* offline or API error — let the app load normally */
+  }
+}
+
 export function mountChrome(active) {
   const el = document.getElementById('nav');
   if (el) el.innerHTML = renderNav(active);
+  if (typeof fetch !== 'undefined' && typeof location !== 'undefined') {
+    enforceOnboarding(fetch, location);
+  }
 }

--- a/public/js/settings.js
+++ b/public/js/settings.js
@@ -1,23 +1,12 @@
 import { api, showError } from './api.js';
-import { formatBRL, reaisToCents, currentMonth } from './format.js';
+import { reaisToCents, currentMonth } from './format.js';
 import { mountChrome } from './chrome.js';
+import { ceilingText, renderLimitRows } from './budget.js';
+
+// Re-exported so existing importers (and tests) can keep reaching them here.
+export { ceilingText, renderLimitRows };
 
 const $ = id => document.getElementById(id);
-
-export function ceilingText(income, fixed, goal) {
-  return `Healthy ceiling ${formatBRL(income - fixed - goal)}`;
-}
-
-export function renderLimitRows(cats, byCat) {
-  return cats.filter(c => c.active).map(c => `
-    <tr class="border-b border-line">
-      <td class="py-2">${c.name}</td>
-      <td class="py-2 text-right">
-        <input type="number" step="0.01" data-cat="${c.id}" value="${(byCat.get(c.id) || 0) / 100}"
-          class="w-32 rounded border border-line bg-card px-2 py-1 text-right font-mono" />
-      </td>
-    </tr>`).join('');
-}
 
 async function loadSettings() {
   try {

--- a/public/js/setup.js
+++ b/public/js/setup.js
@@ -1,0 +1,103 @@
+import { api, showError } from './api.js';
+import { reaisToCents, currentMonth } from './format.js';
+import { ceilingText, renderLimitRows } from './budget.js';
+
+export const SETUP_STEPS = ['Income', 'Fixed costs', 'Savings goal', 'Limits'];
+
+export function progressPct(stepIndex, total) {
+  return Math.round(((stepIndex + 1) / total) * 100);
+}
+
+export function isLastStep(stepIndex, total) {
+  return stepIndex === total - 1;
+}
+
+export function continueLabel(stepIndex, total) {
+  return isLastStep(stepIndex, total) ? 'Start tracking' : 'Continue';
+}
+
+export function renderStepIndicator(activeIndex) {
+  const total = SETUP_STEPS.length;
+  const pills = SETUP_STEPS.map((label, i) => {
+    const state = i < activeIndex ? 'done' : i === activeIndex ? 'active' : 'todo';
+    const current = i === activeIndex ? ' aria-current="step"' : '';
+    return `<li class="step step-${state}"${current}><span class="step-no">${i + 1}</span>${label}</li>`;
+  }).join('');
+  return `
+    <p class="label-caps text-ink-mut">Step ${activeIndex + 1} of ${total}</p>
+    <ol class="step-indicator">${pills}</ol>
+    <div class="meter"><div class="meter-fill" style="width:${progressPct(activeIndex, total)}%"></div></div>`;
+}
+
+// ---- DOM bootstrap (browser only) ----
+const $ = id => document.getElementById(id);
+
+if (typeof document !== 'undefined' && document.getElementById('setup')) {
+  const month = currentMonth();
+  let step = 0;
+  let cats = [];
+
+  function updateCeiling() {
+    $('ceiling').textContent = ceilingText(
+      reaisToCents($('monthly_income').value || 0),
+      reaisToCents($('fixed_costs').value || 0),
+      reaisToCents($('savings_goal').value || 0));
+  }
+
+  function render() {
+    $('indicator').innerHTML = renderStepIndicator(step);
+    document.querySelectorAll('[data-step]').forEach(el => {
+      el.hidden = Number(el.dataset.step) !== step;
+    });
+    $('back').disabled = step === 0;
+    $('continue').textContent = continueLabel(step, SETUP_STEPS.length);
+  }
+
+  async function finish() {
+    try {
+      await api.put('/api/settings', {
+        monthly_income: reaisToCents($('monthly_income').value),
+        fixed_costs: reaisToCents($('fixed_costs').value),
+        savings_goal: reaisToCents($('savings_goal').value),
+      });
+      const puts = cats.filter(c => c.active).map(c => {
+        const inp = $('limits').querySelector(`input[data-cat="${c.id}"]`);
+        return api.put('/api/limits', {
+          category_id: c.id, month, limit_cents: reaisToCents(inp.value || 0),
+        });
+      });
+      await Promise.all(puts);
+      await api.post('/api/onboarding/complete');
+      location.replace('/');
+    } catch (e) { showError(e.message); }
+  }
+
+  async function load() {
+    try {
+      const [s, categories, limits] = await Promise.all([
+        api.get('/api/settings'),
+        api.get('/api/categories'),
+        api.get(`/api/limits?month=${month}`),
+      ]);
+      cats = categories;
+      $('monthly_income').value = s.monthly_income / 100;
+      $('fixed_costs').value = s.fixed_costs / 100;
+      $('savings_goal').value = s.savings_goal / 100;
+      const byCat = new Map(limits.map(l => [l.category_id, l.limit_cents]));
+      $('limits').innerHTML = renderLimitRows(cats, byCat);
+      $('limitsMonth').textContent = month;
+      updateCeiling();
+      render();
+    } catch (e) { showError(e.message); }
+  }
+
+  ['monthly_income', 'fixed_costs', 'savings_goal'].forEach(id =>
+    $(id).addEventListener('input', updateCeiling));
+  $('back').addEventListener('click', () => { if (step > 0) { step--; render(); } });
+  $('continue').addEventListener('click', () => {
+    if (isLastStep(step, SETUP_STEPS.length)) finish();
+    else { step++; render(); }
+  });
+
+  load();
+}

--- a/public/setup.html
+++ b/public/setup.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Gastando — Welcome</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@600;700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="/css/app.css" />
+</head>
+<body>
+  <main class="min-h-screen grid md:grid-cols-2">
+    <!-- Presentation -->
+    <section class="flex flex-col justify-between gap-8 px-8 py-10 md:px-12 md:py-14 bg-paper">
+      <div>
+        <a href="/" class="font-display text-3xl text-ink">Gastando</a>
+        <h1 class="font-display text-4xl md:text-5xl text-ink mt-8 leading-tight">Spend with intention.</h1>
+        <ul class="mt-8 space-y-4 text-ink-mut">
+          <li class="flex items-start gap-3"><span class="step-no mt-0.5">✓</span>Track every card purchase by category</li>
+          <li class="flex items-start gap-3"><span class="step-no mt-0.5">✓</span>Stay under editable monthly limits</li>
+          <li class="flex items-start gap-3"><span class="step-no mt-0.5">✓</span>Simulate a purchase before you commit</li>
+        </ul>
+      </div>
+      <p class="text-sm text-ink-mut">Runs entirely on your machine. No account, no cloud sync.</p>
+    </section>
+
+    <!-- Setup wizard -->
+    <section class="flex items-center justify-center px-6 py-10 md:px-12 bg-card">
+      <div id="setup" class="paper-card w-full max-w-md">
+        <h2 class="font-display text-2xl mb-1">Let's set up your budget</h2>
+        <div id="indicator"></div>
+
+        <div data-step="0" class="mt-6 space-y-4">
+          <h3 class="font-display text-xl">Your monthly income</h3>
+          <label class="field"><span>Monthly income (R$)</span>
+            <input type="number" id="monthly_income" step="0.01" inputmode="decimal" /></label>
+        </div>
+
+        <div data-step="1" class="mt-6 space-y-4" hidden>
+          <h3 class="font-display text-xl">Fixed costs</h3>
+          <p class="text-sm text-ink-mut">Rent, utilities and other bills that don't go on a card.</p>
+          <label class="field"><span>Fixed costs (R$)</span>
+            <input type="number" id="fixed_costs" step="0.01" inputmode="decimal" /></label>
+        </div>
+
+        <div data-step="2" class="mt-6 space-y-4" hidden>
+          <h3 class="font-display text-xl">Savings goal</h3>
+          <p class="text-sm text-ink-mut">How much you want to set aside each month.</p>
+          <label class="field"><span>Savings goal (R$)</span>
+            <input type="number" id="savings_goal" step="0.01" inputmode="decimal" /></label>
+        </div>
+
+        <div data-step="3" class="mt-6 space-y-4" hidden>
+          <h3 class="font-display text-xl">Category limits for <span id="limitsMonth" class="font-mono text-base"></span></h3>
+          <p class="text-sm text-ink-mut">A monthly ceiling per category. You can change these any time in Settings.</p>
+          <table class="w-full text-left"><tbody id="limits"></tbody></table>
+        </div>
+
+        <div class="mt-6 rounded-lg bg-paper border border-line px-4 py-3">
+          <span id="ceiling" class="pill pill-ok"></span>
+        </div>
+
+        <div class="flex items-center gap-3 mt-6">
+          <button id="back" class="btn-ghost">Back</button>
+          <button id="continue" class="btn-primary ml-auto">Continue</button>
+        </div>
+      </div>
+    </section>
+  </main>
+  <script type="module" src="/js/setup.js"></script>
+</body>
+</html>

--- a/src/app.js
+++ b/src/app.js
@@ -15,6 +15,7 @@ function createApp(db) {
   app.use('/api/transactions', require('./routes/transactions')(db));
   app.use('/api/installment-groups', require('./routes/installmentGroups')(db));
   app.use('/api/settings', require('./routes/settings')(db));
+  app.use('/api/onboarding', require('./routes/onboarding')(db));
   app.use('/api/dashboard', require('./routes/dashboard')(db));
   app.use('/api/bi', require('./routes/bi')(db));
   app.use('/api/simulate', require('./routes/simulate')(db));

--- a/src/routes/onboarding.js
+++ b/src/routes/onboarding.js
@@ -1,0 +1,25 @@
+const express = require('express');
+
+const KEY = 'onboarding_complete';
+
+function isComplete(db) {
+  const row = db.prepare('SELECT value FROM settings WHERE key=?').get(KEY);
+  return row ? row.value === '1' : false;
+}
+
+module.exports = (db) => {
+  const router = express.Router();
+
+  router.get('/', (req, res) => {
+    res.json({ complete: isComplete(db) });
+  });
+
+  router.post('/complete', (req, res) => {
+    db.prepare(
+      'INSERT INTO settings (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value=excluded.value'
+    ).run(KEY, '1');
+    res.json({ complete: true });
+  });
+
+  return router;
+};

--- a/test/onboarding.test.js
+++ b/test/onboarding.test.js
@@ -1,0 +1,22 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const request = require('supertest');
+const { makeTestDb } = require('./helpers');
+const { createApp } = require('../src/app');
+
+test('GET /api/onboarding reports incomplete on a fresh database', async () => {
+  const { db } = makeTestDb();
+  const res = await request(createApp(db)).get('/api/onboarding').expect(200);
+  assert.deepEqual(res.body, { complete: false });
+});
+
+test('POST /api/onboarding/complete sets the flag and persists', async () => {
+  const { db } = makeTestDb();
+  const app = createApp(db);
+
+  const done = await request(app).post('/api/onboarding/complete').expect(200);
+  assert.deepEqual(done.body, { complete: true });
+
+  const after = await request(app).get('/api/onboarding').expect(200);
+  assert.deepEqual(after.body, { complete: true });
+});

--- a/test/onboardingGuard.test.js
+++ b/test/onboardingGuard.test.js
@@ -1,0 +1,38 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+
+function stubLocation(pathname) {
+  return { pathname, replaced: null, replace(url) { this.replaced = url; } };
+}
+function stubFetch(complete) {
+  return async () => ({ ok: true, json: async () => ({ complete }) });
+}
+
+test('enforceOnboarding redirects to /setup.html when onboarding is incomplete', async () => {
+  const { enforceOnboarding } = await import('../public/js/chrome.js');
+  const loc = stubLocation('/');
+  await enforceOnboarding(stubFetch(false), loc);
+  assert.equal(loc.replaced, '/setup.html');
+});
+
+test('enforceOnboarding does nothing when onboarding is complete', async () => {
+  const { enforceOnboarding } = await import('../public/js/chrome.js');
+  const loc = stubLocation('/');
+  await enforceOnboarding(stubFetch(true), loc);
+  assert.equal(loc.replaced, null);
+});
+
+test('enforceOnboarding does not redirect when already on the setup page', async () => {
+  const { enforceOnboarding } = await import('../public/js/chrome.js');
+  const loc = stubLocation('/setup.html');
+  await enforceOnboarding(stubFetch(false), loc);
+  assert.equal(loc.replaced, null);
+});
+
+test('enforceOnboarding swallows fetch failures without redirecting', async () => {
+  const { enforceOnboarding } = await import('../public/js/chrome.js');
+  const loc = stubLocation('/');
+  const failing = async () => { throw new Error('network down'); };
+  await enforceOnboarding(failing, loc);
+  assert.equal(loc.replaced, null);
+});

--- a/test/setupRender.test.js
+++ b/test/setupRender.test.js
@@ -1,0 +1,34 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+
+test('SETUP_STEPS lists the four wizard steps in order', async () => {
+  const { SETUP_STEPS } = await import('../public/js/setup.js');
+  assert.deepEqual(SETUP_STEPS, ['Income', 'Fixed costs', 'Savings goal', 'Limits']);
+});
+
+test('progressPct maps the active step to a percentage of total', async () => {
+  const { progressPct } = await import('../public/js/setup.js');
+  assert.equal(progressPct(0, 4), 25);
+  assert.equal(progressPct(1, 4), 50);
+  assert.equal(progressPct(3, 4), 100);
+});
+
+test('isLastStep is true only on the final step', async () => {
+  const { isLastStep } = await import('../public/js/setup.js');
+  assert.equal(isLastStep(0, 4), false);
+  assert.equal(isLastStep(3, 4), true);
+});
+
+test('continueLabel switches to the finish label on the last step', async () => {
+  const { continueLabel } = await import('../public/js/setup.js');
+  assert.equal(continueLabel(0, 4), 'Continue');
+  assert.equal(continueLabel(3, 4), 'Start tracking');
+});
+
+test('renderStepIndicator marks the active step and lists every label', async () => {
+  const { renderStepIndicator, SETUP_STEPS } = await import('../public/js/setup.js');
+  const html = renderStepIndicator(1);
+  for (const label of SETUP_STEPS) assert.ok(html.includes(label), `missing ${label}`);
+  assert.match(html, /Step 2 of 4/);
+  assert.match(html, /aria-current="step"/);
+});


### PR DESCRIPTION
Show a guided, one-time budget setup wizard the first time the app is opened, then route the user straight to the app on every subsequent launch.

Backend
- New /api/onboarding routes: GET reports completion, POST /complete sets the flag. The flag lives in the existing settings table key `onboarding_complete`; its absence is what triggers the wizard, so a freshly seeded install shows it exactly once. No schema migration.
- The wizard persists through the existing PUT /api/settings and PUT /api/limits endpoints — no new write paths.

First-run gate
- enforceOnboarding() runs from mountChrome (which every app page calls) and redirects to /setup.html until onboarding is complete. It no-ops on the setup page itself and swallows fetch failures so a flaky check can never lock the user out.

Setup wizard
- public/setup.html: two-pane "Serene Ledger" layout (presentation + 4-step wizard), responsive stack on mobile.
- public/js/setup.js: Income -> Fixed costs -> Savings goal -> Category limits, pre-filled from current data, with a live healthy-ceiling helper and step indicator. Finishing saves everything, flips the flag, and returns to the dashboard.

Refactor
- Extract shared ceilingText/renderLimitRows into a side-effect-free public/js/budget.js so the setup page no longer imports settings.js (both have a #limits element, which would otherwise fire the settings page bootstrap on the setup page). settings.js re-exports them for back-compat.

Tests
- onboarding API (GET default, POST flips, persistence), the guard's four branches, and the wizard's pure render helpers. 76/76 pass; coverage check passes (onboarding route at 100%).