### PR TITLE
Phase 1 — Installments Command-Center (Parcelas overview, edit, pay-off early)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,11 @@
 services:
   gastando:
     build: .
+    environment:
+      # Bind to all interfaces *inside* the container so the published port is
+      # reachable from the host. The container's network namespace is the
+      # isolation boundary; the host still only exposes the mapped port.
+      - HOST=0.0.0.0
     ports:
       - "3000:3000"
     volumes:

--- a/docs/suggestions.md
+++ b/docs/suggestions.md
@@ -1,0 +1,133 @@
+# Gastando — Improvement & Feature Suggestions
+
+- Date: 2026-06-26
+- Scope: review of current functionality with prioritized improvements and new features
+- Based on: full read of `src/` (hexagonal: domain / application / adapters / infra),
+  `public/` frontend, `migrations/`, and `docs/spec.md`
+
+Suggestions are prioritized by **leverage per effort** and **fit to the stated
+purpose** (a local-first, single-user credit-card budget tracker). Each item is
+sized **S** (~hours), **M** (~half-day to day), or **L** (multi-day), with the
+gap or rationale grounded in the current code.
+
+---
+
+## What the app does today
+
+A local-first, single-user **credit-card budget tracker**: Node + Express 5 +
+better-sqlite3 + Zod, TypeScript with a clean hexagonal architecture, vanilla
+JS + Tailwind ("Serene Ledger") frontend, shipped as self-contained binaries.
+
+**Health:** typecheck clean, 104 tests, 80% coverage gate, tidy
+domain/application/adapters/infra split — in good shape to extend.
+
+**Working features:** onboarding wizard → dashboard (savings hero + per-category
+meters with **overspend carryover**) → transactions (CRUD, pagination,
+installment expansion) → settings (per-month limit history, groups/categories/
+cards, savings model with ceiling reconciliation) → 5 BI charts → installment
+what-if simulator → view-only category detail with trend.
+
+---
+
+## Tier 1 — Highest-value new features (strong fit)
+
+### 1. Installments command-center ("Parcelas") — [M]
+Parcelas are a first-class, very-Brazilian credit-card concept, but today you can
+only **create** and **delete** a group. There is **no list/overview, and editing
+is specced but unimplemented** — `InstallmentRepository` exposes only
+`createPurchase` / `remove` (no GET, no re-expand).
+
+**Add:** a page listing every active installment group — remaining balance,
+parcelas paid/left (e.g. 3/6), monthly amount, total future committed outflow —
+plus edit (atomic re-expand) and "pay off early." The BI `installment-forecast`
+series already computes the monthly commitment; this surfaces it as something
+actionable. Highest fit, and it closes a real spec gap.
+
+### 2. Recurring / subscription transactions — [M]
+Manual entry is the **only** input, yet the seed data is full of monthly
+subscriptions (Apple, Claude, Disney+, seguro). Add a "recurring" template
+(category / card / amount / day) that one-click materializes each month's charges
+— optionally flagging when an amount changed vs last month. Removes the single
+biggest friction in the app.
+
+### 3. Suggested limits from history — [S]
+Half the app is "spend vs limit," but limits are set blind. Add "use last month"
+/ "use 3-month average" buttons in **Settings** and the **onboarding** limits
+step. The data is one `spendByCategoryMonth` call per month — small effort, turns
+limit-setting from guesswork into data-driven.
+
+### 4. Savings history — the missing half of BI — [M]
+Projected savings vs goal is the **dashboard hero**, yet BI is entirely
+spend-side — there is no savings trend anywhere. Add a "Savings over time" chart
+(income − fixed − actual spend per month, vs goal; realized vs projected). The
+one view that speaks directly to the headline number.
+
+---
+
+## Tier 1.5 — Cheap, high value
+
+### 5. CSV export + in-app DB backup/restore — [S–M]
+Export transactions/dashboard to CSV; back up & restore the SQLite file from the
+UI (today the README says "copy the file by hand"). A simple CSV/paste
+**importer** (the spec's "may be revisited") is the biggest lever against
+manual-entry fatigue.
+
+### 6. Per-card statement view — [L, most on-theme]
+It is a **credit-card** tracker, but cards are just name + active. Add closing/due
+day per card and a "projected bill for card X this month" view
+(`spendByCardMonth` already aggregates the data). This is what makes it a
+credit-card app rather than a generic budget app.
+
+---
+
+## Tier 2 — Improvements to existing features
+
+- **Surface filters on Transactions — [S].** The API supports `category_id` /
+  `card_id`, but the page only filters by month. Add category/card dropdowns + a
+  description search.
+- **Three-state budget meter — [S].** Status is binary `ok | over`; add
+  "approaching" (≥80%) so the dashboard warns *before* a limit is blown.
+- **Implement installment-group edit — [S–M].** Standalone correctness gap vs the
+  spec (see #1): editing amount/count should re-expand the child transactions
+  atomically. Today only create/delete exist, and editing a single parcela row
+  silently desyncs it from the group total.
+- **Escape rendered HTML — [S].** Output is interpolated straight into
+  `innerHTML` (`${c.name}`, `${r.description}`, `${groupName}`) with no escaping.
+  A category like "Casa & Jardim" or a description containing `<` renders wrong.
+  Low security risk (single local user) but a real rendering bug — add an
+  `escapeHtml` helper.
+- **Replace `prompt()` / `confirm()` in Settings — [M].** Rename/recolor/add use
+  raw browser prompts; recolor asks you to *type* a palette token. Inline editing
+  + color swatches.
+
+---
+
+## Tier 3 — Technical / hardening
+
+- **PR CI — [S].** Release workflows are tag-triggered; there is **no
+  PR-triggered `npm test` + `typecheck` + coverage gate**, so the 104 tests and
+  80% rule do not actually gate merges. Add one.
+- **Bind to 127.0.0.1 by default — [S].** `listen(port)` binds *all* interfaces;
+  a "runs entirely on your machine," no-auth app is currently reachable by anyone
+  on the LAN. Default to loopback with an optional `HOST` override.
+- **Linter/formatter + editorconfig — [S].** None present (Biome, or
+  ESLint + Prettier).
+- **Housekeeping — [S].** Move the root mockups `card.html` /
+  `orcamento-cartoes.html` into `docs/`.
+
+---
+
+## Deliberately out of scope
+
+Respecting the locked non-goals in `spec.md`: multi-user / authentication, cloud
+sync, real-time bank integration, native mobile app.
+
+---
+
+## Recommended starting point
+
+- **#1 Installments** and **#3 Suggested limits** — most value per effort; both
+  lean on existing data/services.
+- **#2 Recurring transactions** — biggest friction win.
+- **PR CI** and **localhost binding** — quick hardening wins worth doing
+  regardless.

--- a/docs/superpowers/plans/2026-06-27-phase-0-foundation-hardening.md
+++ b/docs/superpowers/plans/2026-06-27-phase-0-foundation-hardening.md
@@ -1,0 +1,386 @@
+# Phase 0 — Foundation Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every later feature safe to build on — gate merges with CI, stop binding the server to all interfaces, finish HTML escaping, add a formatter/linter, and tidy stray files.
+
+**Architecture:** No new runtime architecture. Tasks are cross-cutting hardening: a GitHub Actions workflow, a one-line server bind change, applying the existing `esc()` helper to the remaining unescaped DOM interpolations, a Biome config, and a file move.
+
+**Tech Stack:** Node 22, TypeScript 5.9 (strict), Express 5, better-sqlite3, `node:test` + c8 + supertest, Biome (new), GitHub Actions.
+
+## Global Constraints
+
+These apply to **every** task in this plan and the other phase plans.
+
+- Node 22; `package.json` is `"type": "commonjs"`; source is TypeScript run via `tsx`.
+- Money is integer **cents**. Months are `YYYY-MM`; dates are `YYYY-MM-DD`.
+- Hexagonal layering: `domain → application → adapters → infra`; dependencies point inward. Ports live in `src/domain/ports/index.ts`; entities in `src/domain/entities/index.ts`; errors are `AppError(status, message)` from `src/domain/errors`.
+- Tests are CommonJS (`const { test } = require('node:test')`) in `test/*.test.ts`, run by `npm test`. API tests use `supertest` + `createApp(ctx.db)`; DB tests use `makeTestDb()` from `test/helpers` (in-memory, runs every migration **except** `002_seed.sql`).
+- Coverage gate: `npm run coverage` (c8) requires **≥80%** lines/statements/functions/branches over `src/**/*.ts` except `src/server.ts`.
+- HTTP-edge validation uses zod schemas in `src/adapters/http/schemas/` parsed with `parse()` from `src/adapters/http/validate`; existence rules live in use-cases and throw `AppError`.
+- Frontend is vanilla ESM in `public/js/` (made modules by `public/js/package.json`), styled with the "Serene Ledger" Tailwind system. UI copy is English; data (category names, currency) is pt-BR. Frontend render functions are pure and unit-tested by importing the module and asserting on the returned HTML string.
+- Commit after every task with a conventional-commit message.
+
+---
+
+### Task 1: PR-triggered CI workflow
+
+**Files:**
+- Create: `.github/workflows/ci.yml`
+
+**Interfaces:**
+- Consumes: existing npm scripts `typecheck` and `coverage`.
+- Produces: a required status check on PRs and pushes to `main`.
+
+- [ ] **Step 1: Confirm the gate passes locally first**
+
+Run: `npm run typecheck && npm run coverage`
+Expected: typecheck prints nothing/0 errors; coverage prints the c8 table and exits 0 (all four metrics ≥80%). If this fails, stop — CI would only encode a broken baseline.
+
+- [ ] **Step 2: Write the workflow**
+
+Create `.github/workflows/ci.yml`:
+
+```yaml
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: npm ci
+      - run: npm run typecheck
+      - run: npm run coverage
+```
+
+- [ ] **Step 3: Validate the YAML parses**
+
+Run: `npx --yes js-yaml .github/workflows/ci.yml >/dev/null && echo OK`
+Expected: `OK` (no YAML syntax error).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci: run typecheck + coverage on PRs and main"
+```
+
+- [ ] **Step 5: (Post-merge, manual) make it required**
+
+In GitHub repo settings → Branches → add a branch protection rule for `main` requiring the `test` check. Note this in the PR description; it cannot be done from code.
+
+---
+
+### Task 2: Bind the HTTP server to loopback by default
+
+**Files:**
+- Modify: `src/server.ts:13-17`
+
+**Interfaces:**
+- Produces: server binds to `process.env.HOST || '127.0.0.1'`; a `HOST=0.0.0.0` override restores LAN exposure.
+
+Note: `src/server.ts` is excluded from coverage (`.c8rc.json`), so this needs no unit test; verify by running the server.
+
+- [ ] **Step 1: Edit the listen call**
+
+In `src/server.ts`, replace:
+
+```ts
+const port = Number(process.env.PORT) || 3000;
+buildAppFromDb(db).listen(port, () => {
+  console.log(`Gastando listening on :${port}`);
+  openBrowser(`http://localhost:${port}`);
+});
+```
+
+with:
+
+```ts
+const port = Number(process.env.PORT) || 3000;
+const host = process.env.HOST || '127.0.0.1';
+buildAppFromDb(db).listen(port, host, () => {
+  console.log(`Gastando listening on http://${host}:${port}`);
+  openBrowser(`http://localhost:${port}`);
+});
+```
+
+- [ ] **Step 2: Verify it serves on loopback**
+
+Run: `PORT=3999 npm start &` then `sleep 1 && curl -fs http://127.0.0.1:3999/api/health` (then `kill %1`)
+Expected: `{"ok":true}` from `127.0.0.1`. (Optional: confirm `curl http://$(hostname -I | awk '{print $1}'):3999/api/health` now refuses/times out.)
+
+- [ ] **Step 3: Typecheck**
+
+Run: `npm run typecheck`
+Expected: 0 errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/server.ts
+git commit -m "fix: bind server to 127.0.0.1 by default (HOST override)"
+```
+
+---
+
+### Task 3: Apply `esc()` to the remaining unescaped interpolations
+
+**Context:** `esc()` already exists in `public/js/format.js:16` and is already used in `public/js/budget.js`. The unescaped user-controlled interpolations that remain are in `ui.js`, `dashboard.js`, `transactions.js`, `category.js`, `simulate.js`, `settings.js`.
+
+**Files:**
+- Modify: `public/js/ui.js:1,25` (groupTag)
+- Modify: `public/js/dashboard.js:2,36,48,49` (renderGroups)
+- Modify: `public/js/transactions.js:2,13,25` (renderRows, option labels)
+- Modify: `public/js/category.js:2,21` (renderRows)
+- Modify: `public/js/simulate.js:2,44` (option labels)
+- Modify: `public/js/settings.js:2,122` (card names)
+- Test: `test/escaping.test.ts` (new)
+
+**Interfaces:**
+- Consumes: `esc` from `public/js/format.js`.
+- Produces: every render helper that prints a category/group/card name, examples, or description HTML-escapes it.
+
+- [ ] **Step 1: Write failing escaping tests**
+
+Create `test/escaping.test.ts`:
+
+```ts
+const { test } = require('node:test');
+const assert = require('node:assert');
+
+test('groupTag escapes the group name', async () => {
+  const { groupTag } = await import('../public/js/ui.js');
+  const html = groupTag('Casa & Jardim <x>');
+  assert.match(html, /Casa &amp; Jardim &lt;x&gt;/);
+  assert.doesNotMatch(html, /<x>/);
+});
+
+test('dashboard renderGroups escapes category name, examples and group header', async () => {
+  const { renderGroups } = await import('../public/js/dashboard.js');
+  const d = {
+    categories: [{ category_id: 1, name: '<b>Boom</b>', examples: 'a & b', group_id: 1,
+      group_name: 'G&G', limit_cents: 100, spent_cents: 0, status: 'ok' }],
+    groups: [{ group_id: 1, name: 'G&G', limit_cents: 100, spent_cents: 0 }],
+    totals: {},
+  };
+  const html = renderGroups(d);
+  assert.doesNotMatch(html, /<b>Boom<\/b>/);
+  assert.match(html, /&lt;b&gt;Boom/);
+  assert.match(html, /a &amp; b/);
+});
+
+test('transactions renderRows escapes the description', async () => {
+  const { renderRows } = await import('../public/js/transactions.js');
+  const html = renderRows([{ id: 1, date: '2026-06-01', description: '<img src=x>',
+    amount_cents: 100, installment_no: null, installment_total: null, installment_group_id: null }]);
+  assert.doesNotMatch(html, /<img src=x>/);
+  assert.match(html, /&lt;img src=x&gt;/);
+});
+```
+
+- [ ] **Step 2: Run the tests to confirm they fail**
+
+Run: `npm test -- --test-name-pattern="escapes"` (or `npx tsx --test test/escaping.test.ts`)
+Expected: FAIL — raw `<b>`/`<img>` present because the helpers don't escape yet.
+
+- [ ] **Step 3: Escape in `ui.js`**
+
+Change line 1 import and the `groupTag` return:
+
+```js
+import { formatBRL, esc } from './format.js';
+```
+```js
+  return `<span class="tag ${cls}">${esc(groupName)}</span>`;
+```
+
+- [ ] **Step 4: Escape in `dashboard.js`**
+
+Change the format import to include `esc`:
+
+```js
+import { formatBRL, currentMonth, esc } from './format.js';
+```
+
+In `renderGroups`, wrap the three user strings:
+- the group header: `<h2 ...>${esc(g.name)}</h2>`
+- the category name: `<div class="font-semibold flex items-center gap-2">${esc(c.name)} ${groupTag(g.name)}</div>`
+- the examples line: `${c.examples ? `<div class="text-xs text-ink-mut mt-0.5">${esc(c.examples)}</div>` : ''}`
+
+- [ ] **Step 5: Escape in `transactions.js`, `category.js`, `simulate.js`, `settings.js`**
+
+In each, add `esc` to the `./format.js` import and wrap:
+- `transactions.js` `renderRows`: `${esc(r.description)}`; `loadSelectors` option labels: `${esc(c.name)}` (both category and card maps).
+- `category.js` `renderRows`: `${esc(r.description)}`.
+- `simulate.js` `loadCategories`: option label `${esc(c.name)}`.
+- `settings.js` `loadCards`: `<span>${esc(c.name)}</span>`.
+
+- [ ] **Step 6: Run the full test suite**
+
+Run: `npm test`
+Expected: PASS — new escaping tests pass and existing render tests still pass (accented names like `Pão de Açúcar` are unaffected by `esc`).
+
+- [ ] **Step 7: Audit for any leftover raw interpolation of names/descriptions**
+
+Run: `grep -rn '${\(c\.name\|g\.name\|r\.description\|c\.examples\)}' public/js`
+Expected: no matches (every such interpolation now goes through `esc(...)`). If any remain, wrap them and re-run `npm test`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add public/js test/escaping.test.ts
+git commit -m "fix: HTML-escape category/group/card names and descriptions"
+```
+
+---
+
+### Task 4: Add Biome (formatter + linter) and EditorConfig
+
+**Files:**
+- Modify: `package.json` (devDependency + scripts)
+- Create: `biome.json`
+- Create: `.editorconfig`
+- Modify: `.github/workflows/ci.yml` (add a format/lint check)
+
+**Interfaces:**
+- Produces: `npm run lint` and `npm run format`; CI fails on unformatted or lint-erroring code.
+
+- [ ] **Step 1: Install Biome**
+
+Run: `npm install --save-dev --save-exact @biomejs/biome@2`
+Expected: it appears under `devDependencies`.
+
+- [ ] **Step 2: Write `biome.json` matching the existing style**
+
+The codebase uses 2-space indent, single quotes, semicolons, and trailing commas. Encode that so formatting churn is minimal:
+
+```json
+{
+  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
+  "files": { "includes": ["src/**", "public/js/**", "test/**"] },
+  "formatter": { "enabled": true, "indentStyle": "space", "indentWidth": 2, "lineWidth": 100 },
+  "javascript": { "formatter": { "quoteStyle": "single", "trailingCommas": "all", "semicolons": "always" } },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "suspicious": { "noExplicitAny": "off" },
+      "style": { "noParameterAssign": "off" }
+    }
+  }
+}
+```
+
+- [ ] **Step 3: Add scripts to `package.json`**
+
+In `"scripts"` add:
+
+```json
+"lint": "biome check .",
+"format": "biome format --write ."
+```
+
+- [ ] **Step 4: Format the codebase (its own commit)**
+
+Run: `npm run format`
+Expected: Biome rewrites files to the canonical style. Review the diff — it should be whitespace/quote-level only, no logic changes.
+
+```bash
+git add -A
+git commit -m "style: apply Biome formatting"
+```
+
+- [ ] **Step 5: Fix or scope lint findings**
+
+Run: `npm run lint`
+Expected: either clean, or a finite list. For each finding, fix it; if a rule is genuinely too noisy for this codebase, disable that specific rule in `biome.json` (do not blanket-ignore files). Re-run until `npm run lint` exits 0.
+
+- [ ] **Step 6: Add `.editorconfig`**
+
+Create `.editorconfig`:
+
+```ini
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+```
+
+- [ ] **Step 7: Wire lint into CI**
+
+In `.github/workflows/ci.yml`, add a step after `npm ci` and before typecheck:
+
+```yaml
+      - run: npm run lint
+```
+
+- [ ] **Step 8: Verify the whole gate**
+
+Run: `npm run lint && npm run typecheck && npm test`
+Expected: all pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add package.json package-lock.json biome.json .editorconfig .github/workflows/ci.yml
+git commit -m "build: add Biome lint/format + editorconfig and gate in CI"
+```
+
+---
+
+### Task 5: Housekeeping — move root mockups into `docs/`
+
+**Files:**
+- Move: `card.html` → `docs/card.html`
+- Move: `orcamento-cartoes.html` → `docs/orcamento-cartoes.html`
+
+Note: leave `card.md` at the root — `docs/spec.md` references it as the domain source of truth. The two `.html` files are static design mockups not served by the app (`pkg` assets are `public/**` + `migrations/**` only), so moving them is safe.
+
+- [ ] **Step 1: Confirm nothing references the files**
+
+Run: `grep -rn "card.html\|orcamento-cartoes.html" --include=*.ts --include=*.js --include=*.json --include=Dockerfile . | grep -v node_modules`
+Expected: no runtime references (matches, if any, are only in docs/markdown).
+
+- [ ] **Step 2: Move with git**
+
+```bash
+git mv card.html docs/card.html
+git mv orcamento-cartoes.html docs/orcamento-cartoes.html
+```
+
+- [ ] **Step 3: Verify build still green**
+
+Run: `npm run typecheck && npm test`
+Expected: pass (no code depended on these).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "chore: move root HTML mockups into docs/"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** PR CI (Task 1), localhost binding (Task 2), escaping (Task 3 — corrected to *apply* the existing `esc()` rather than create a helper), linter/formatter + editorconfig (Task 4), housekeeping (Task 5). All Tier 3 + escaping items covered.
+- **Placeholder scan:** none — every code step shows the exact edit; lint-fix step (4.5) is bounded by "re-run until exit 0".
+- **Ordering:** CI first so the rest is gated; escaping before Biome so new escaped code is formatted in one pass; housekeeping last (independent).
+- **Type consistency:** no new types introduced. `esc` is the existing export from `format.js`.

--- a/docs/superpowers/plans/2026-06-27-phase-1-installments-command-center.md
+++ b/docs/superpowers/plans/2026-06-27-phase-1-installments-command-center.md
@@ -1,0 +1,842 @@
+# Phase 1 — Installments Command-Center ("Parcelas") Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give installment groups a first-class overview page (remaining balance, parcelas paid/left, monthly amount, next charge), plus atomic **edit** (re-expand) and **pay-off early** — closing the spec gap where only create/delete exist.
+
+**Architecture:** Extend the existing `InstallmentRepository` port and its better-sqlite3 implementation with read (`listWithProgress`) and write (`update`, `payOffEarly`) operations; surface them through the installments use-case, the existing `/api/installment-groups` controller, and a new `public/parcelas.html` page. All multi-row writes stay inside a single SQLite transaction, mirroring `createPurchase`.
+
+**Tech Stack:** TypeScript hexagonal (domain/application/adapters/infra), Express 5, better-sqlite3, zod, `node:test` + supertest, vanilla ESM frontend.
+
+## Global Constraints
+
+(Identical to Phase 0 — repeated so this plan stands alone.)
+
+- Node 22; money in integer **cents**; months `YYYY-MM`, dates `YYYY-MM-DD`.
+- Hexagonal layering, deps inward. Ports in `src/domain/ports/index.ts`, entities in `src/domain/entities/index.ts`, errors via `AppError(status, message)`.
+- Tests are CommonJS `require('node:test')` in `test/*.test.ts`; DB tests use `makeTestDb()` (in-memory, all migrations except `002_seed.sql`); API tests use `supertest` + `createApp(ctx.db)`.
+- Coverage ≥80% over `src/**/*.ts` (`npm run coverage`).
+- HTTP validation via zod schemas + `parse()`; existence rules in use-cases.
+- Frontend render functions are pure and unit-tested by importing the module and asserting on the HTML string; DOM bootstrap (the `if (typeof document !== 'undefined')` block) follows existing pages and is not unit-tested.
+- Commit after each task.
+
+## Design Decisions (review before executing)
+
+1. **"Paid" vs "remaining" is split by an `asOf` month.** A parcela whose month ≤ `asOf` counts as landed/paid; month > `asOf` is remaining. `asOf` defaults to the server's current month, overridable via `?month=YYYY-MM`. There is no separate "paid" flag — parcelas are just dated transactions, so this is the natural definition.
+2. **`monthly_cents` = the largest child amount.** `splitCents` puts the remainder cent on the first parcelas, so the max child is the representative headline figure.
+3. **Pay-off early collapses the remaining schedule into the current month** — it re-dates every not-yet-landed parcela (month > `asOf`) to `${asOf}-01`, so the whole remaining balance hits this month's spend (exactly what paying a card off early does to the statement). `total_cents`/`total_count` are unchanged, preserving the invariant that children sum to `total_cents`. This keeps history intact and is fully reversible by editing.
+
+---
+
+### Task 1: Repository read — `listWithProgress`
+
+**Files:**
+- Modify: `src/domain/entities/index.ts` (add `InstallmentProgress`)
+- Modify: `src/domain/ports/index.ts:54-61` (extend `InstallmentRepository`)
+- Modify: `src/infra/repositories/installments.ts`
+- Test: `test/installments.test.ts` (append)
+
+**Interfaces:**
+- Produces: `InstallmentProgress` entity and `InstallmentRepository.listWithProgress(asOfMonth: string): InstallmentProgress[]`.
+
+```ts
+// src/domain/entities/index.ts
+export interface InstallmentProgress {
+  id: number; description: string; category_id: number; card_id: number;
+  category_name: string; card_name: string;
+  total_cents: number; total_count: number; first_month: string;
+  paid_count: number; remaining_count: number;
+  paid_cents: number; remaining_cents: number;
+  monthly_cents: number; next_month: string | null;
+}
+```
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/installments.test.ts`:
+
+```ts
+const { makeInstallmentRepository } = require('../src/infra/repositories/installments');
+
+test('listWithProgress splits paid/remaining by asOf month', () => {
+  const ctx = makeTestDb();
+  const repo = makeInstallmentRepository(ctx.db);
+  const id = repo.createPurchase({ category_id: ctx.categoryId, card_id: ctx.cardId,
+    description: 'Avianca', total_cents: 60000, count: 6, first_month: '2026-06' });
+  // June, July, Aug landed (<= 2026-08); Sep, Oct, Nov remaining.
+  const rows = repo.listWithProgress('2026-08');
+  assert.equal(rows.length, 1);
+  const r = rows[0];
+  assert.equal(r.id, id);
+  assert.equal(r.category_name, 'Supermercado');
+  assert.equal(r.card_name, 'Nubank');
+  assert.equal(r.total_count, 6);
+  assert.equal(r.paid_count, 3);
+  assert.equal(r.remaining_count, 3);
+  assert.equal(r.paid_cents, 30000);
+  assert.equal(r.remaining_cents, 30000);
+  assert.equal(r.monthly_cents, 10000);
+  assert.equal(r.next_month, '2026-09');
+});
+```
+
+- [ ] **Step 2: Run it; confirm it fails**
+
+Run: `npx tsx --test test/installments.test.ts`
+Expected: FAIL — `repo.listWithProgress is not a function`.
+
+- [ ] **Step 3: Add the port method**
+
+In `src/domain/ports/index.ts`, add to `InstallmentRepository` (and import `InstallmentProgress`):
+
+```ts
+import type { Group, Category, Card, Transaction, InstallmentProgress } from '../entities';
+```
+```ts
+  listWithProgress(asOfMonth: string): InstallmentProgress[];
+```
+
+- [ ] **Step 4: Implement it**
+
+In `src/infra/repositories/installments.ts`, add to the returned object:
+
+```ts
+    listWithProgress(asOfMonth: string) {
+      return db.prepare(
+        `SELECT g.id, g.description, g.category_id, g.card_id,
+                cat.name AS category_name, crd.name AS card_name,
+                g.total_cents, g.total_count, g.first_month,
+                COALESCE(SUM(CASE WHEN strftime('%Y-%m', t.date) <= @asOf THEN 1 ELSE 0 END), 0) AS paid_count,
+                COALESCE(SUM(CASE WHEN strftime('%Y-%m', t.date) >  @asOf THEN 1 ELSE 0 END), 0) AS remaining_count,
+                COALESCE(SUM(CASE WHEN strftime('%Y-%m', t.date) <= @asOf THEN t.amount_cents ELSE 0 END), 0) AS paid_cents,
+                COALESCE(SUM(CASE WHEN strftime('%Y-%m', t.date) >  @asOf THEN t.amount_cents ELSE 0 END), 0) AS remaining_cents,
+                COALESCE(MAX(t.amount_cents), 0) AS monthly_cents,
+                MIN(CASE WHEN strftime('%Y-%m', t.date) > @asOf THEN strftime('%Y-%m', t.date) END) AS next_month
+         FROM installment_groups g
+         JOIN categories cat ON cat.id = g.category_id
+         JOIN cards crd ON crd.id = g.card_id
+         LEFT JOIN transactions t ON t.installment_group_id = g.id
+         GROUP BY g.id
+         ORDER BY g.first_month, g.id`,
+      ).all({ asOf: asOfMonth }) as import('../../domain/entities').InstallmentProgress[];
+    },
+```
+
+- [ ] **Step 5: Run the test; confirm pass**
+
+Run: `npx tsx --test test/installments.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/domain/entities/index.ts src/domain/ports/index.ts src/infra/repositories/installments.ts test/installments.test.ts
+git commit -m "feat(installments): repository listWithProgress for the overview"
+```
+
+---
+
+### Task 2: Repository write — `update` (atomic re-expand)
+
+**Files:**
+- Modify: `src/domain/ports/index.ts` (`InstallmentRepository.update`)
+- Modify: `src/infra/repositories/installments.ts`
+- Test: `test/installments.test.ts` (append)
+
+**Interfaces:**
+- Produces: `InstallmentRepository.update(id: number, p: { category_id: number; card_id: number; description?: string; total_cents: number; count: number; first_month: string }): void` — throws `AppError(404)` if the group is absent.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+const { AppError } = require('../src/domain/errors');
+
+test('update re-expands children to the new count/total atomically', () => {
+  const ctx = makeTestDb();
+  const repo = makeInstallmentRepository(ctx.db);
+  const id = repo.createPurchase({ category_id: ctx.categoryId, card_id: ctx.cardId,
+    description: 'TV', total_cents: 60000, count: 6, first_month: '2026-06' });
+  repo.update(id, { category_id: ctx.categoryId, card_id: ctx.cardId, description: 'TV',
+    total_cents: 30000, count: 3, first_month: '2026-07' });
+  const all = ctx.db.prepare('SELECT * FROM transactions WHERE installment_group_id=? ORDER BY date').all(id);
+  assert.equal(all.length, 3);
+  assert.deepEqual(all.map(t => t.date.slice(0, 7)), ['2026-07', '2026-08', '2026-09']);
+  assert.equal(all.reduce((s, t) => s + t.amount_cents, 0), 30000);
+  assert.equal(all[0].installment_total, 3);
+  const g = ctx.db.prepare('SELECT * FROM installment_groups WHERE id=?').get(id);
+  assert.equal(g.total_count, 3);
+  assert.equal(g.first_month, '2026-07');
+});
+
+test('update on a missing group throws 404', () => {
+  const ctx = makeTestDb();
+  const repo = makeInstallmentRepository(ctx.db);
+  assert.throws(
+    () => repo.update(9999, { category_id: ctx.categoryId, card_id: ctx.cardId,
+      description: '', total_cents: 1000, count: 2, first_month: '2026-06' }),
+    (e) => e instanceof AppError && e.status === 404);
+});
+```
+
+- [ ] **Step 2: Run; confirm fail**
+
+Run: `npx tsx --test test/installments.test.ts`
+Expected: FAIL — `repo.update is not a function`.
+
+- [ ] **Step 3: Add the port method**
+
+In `src/domain/ports/index.ts` `InstallmentRepository`:
+
+```ts
+  update(id: number, p: {
+    category_id: number; card_id: number; description?: string;
+    total_cents: number; count: number; first_month: string;
+  }): void;                              // atomic re-expand; throws AppError(404) if absent
+```
+
+- [ ] **Step 4: Implement it**
+
+In `src/infra/repositories/installments.ts` (reuses `splitCents`, `addMonths`, `AppError` already imported):
+
+```ts
+    update(id, p): void {
+      const { category_id, card_id, description = '', total_cents, count, first_month } = p;
+      const tx = db.transaction(() => {
+        const exists = db.prepare('SELECT id FROM installment_groups WHERE id=?').get(id);
+        if (!exists) throw new AppError(404, 'installment group not found');
+        db.prepare('DELETE FROM transactions WHERE installment_group_id=?').run(id);
+        db.prepare(
+          `UPDATE installment_groups
+           SET description=?, total_cents=?, total_count=?, first_month=?, category_id=?, card_id=?
+           WHERE id=?`,
+        ).run(description, total_cents, count, first_month, category_id, card_id, id);
+        const amounts = splitCents(total_cents, count);
+        const insert = db.prepare(
+          `INSERT INTO transactions (date, category_id, card_id, amount_cents, description,
+            installment_group_id, installment_no, installment_total)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)`);
+        amounts.forEach((amt, i) => {
+          const month = addMonths(first_month, i);
+          insert.run(`${month}-01`, category_id, card_id, amt, description, id, i + 1, count);
+        });
+      });
+      tx();
+    },
+```
+
+- [ ] **Step 5: Run; confirm pass**
+
+Run: `npx tsx --test test/installments.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/domain/ports/index.ts src/infra/repositories/installments.ts test/installments.test.ts
+git commit -m "feat(installments): atomic update (re-expand) in the repository"
+```
+
+---
+
+### Task 3: Use-case `list` + `update` (with reference checks) and DI wiring
+
+**Files:**
+- Modify: `src/application/use-cases/installments.ts`
+- Modify: `src/infra/composition.ts:73` (pass categories + cards)
+- Test: `test/installments.test.ts` (append)
+
+**Interfaces:**
+- Consumes: `InstallmentRepository.listWithProgress`, `.update`; `CategoryRepository.findById`, `CardRepository.findById`.
+- Produces: `makeInstallmentUseCases({ installments, categories, cards })` now also returns `list(asOfMonth: string): InstallmentProgress[]` and `update(id: number, input: UpdateInstallmentInput): void` (throws `AppError(400)` for unknown category/card).
+
+```ts
+export interface UpdateInstallmentInput {
+  category_id: number; card_id: number; description?: string;
+  total_cents: number; count: number; first_month: string;
+}
+```
+
+- [ ] **Step 1: Write the failing test (use-case wiring)**
+
+```ts
+const { createApp } = require('../src/app'); // already imported at top of file
+
+test('use-case update rejects an unknown category with 400', async () => {
+  const ctx = makeTestDb();
+  const app = createApp(ctx.db);
+  const res = await request(app).post('/api/transactions').send({ category_id: ctx.categoryId,
+    card_id: ctx.cardId, description: 'X', installment_total_cents: 1200, installment_count: 2,
+    first_month: '2026-06' }).expect(201);
+  await request(app).put(`/api/installment-groups/${res.body.installment_group_id}`).send({
+    category_id: 999999, card_id: ctx.cardId, total_cents: 1200, count: 2, first_month: '2026-06',
+  }).expect(400);
+});
+```
+
+(This drives Tasks 3+4 together; it stays red until the controller exists in Task 4. Run it after Task 4. For Task 3, prove the use-case in isolation with the assertion below.)
+
+```ts
+const { makeInstallmentUseCases } = require('../src/application/use-cases/installments');
+const { makeCategoryRepository } = require('../src/infra/repositories/categories');
+const { makeCardRepository } = require('../src/infra/repositories/cards');
+
+test('use-case list returns progress rows', () => {
+  const ctx = makeTestDb();
+  const repo = makeInstallmentRepository(ctx.db);
+  repo.createPurchase({ category_id: ctx.categoryId, card_id: ctx.cardId, description: 'A',
+    total_cents: 1200, count: 2, first_month: '2026-06' });
+  const uc = makeInstallmentUseCases({ installments: repo,
+    categories: makeCategoryRepository(ctx.db), cards: makeCardRepository(ctx.db) });
+  assert.equal(uc.list('2026-06').length, 1);
+});
+```
+
+- [ ] **Step 2: Run; confirm fail**
+
+Run: `npx tsx --test test/installments.test.ts`
+Expected: FAIL — `makeInstallmentUseCases` does not accept categories/cards / `uc.list` undefined.
+
+- [ ] **Step 3: Rewrite the use-case**
+
+Replace `src/application/use-cases/installments.ts` with:
+
+```ts
+import type {
+  InstallmentRepository, CategoryRepository, CardRepository,
+} from '../../domain/ports';
+import type { InstallmentProgress } from '../../domain/entities';
+import { AppError } from '../../domain/errors';
+
+export interface InstallmentUseCaseDeps {
+  installments: InstallmentRepository;
+  categories: CategoryRepository;
+  cards: CardRepository;
+}
+
+export interface UpdateInstallmentInput {
+  category_id: number; card_id: number; description?: string;
+  total_cents: number; count: number; first_month: string;
+}
+
+export function makeInstallmentUseCases(deps: InstallmentUseCaseDeps) {
+  const { installments, categories, cards } = deps;
+
+  function assertRefs(categoryId: number, cardId: number): void {
+    if (!categories.findById(categoryId)) throw new AppError(400, 'category_id does not exist');
+    if (!cards.findById(cardId)) throw new AppError(400, 'card_id does not exist');
+  }
+
+  return {
+    list(asOfMonth: string): InstallmentProgress[] {
+      return installments.listWithProgress(asOfMonth);
+    },
+    update(id: number, input: UpdateInstallmentInput): void {
+      assertRefs(input.category_id, input.card_id);
+      installments.update(id, input);
+    },
+    // Throws AppError(404) from the repository if the group does not exist.
+    remove(id: number): void {
+      installments.remove(id);
+    },
+  };
+}
+```
+
+- [ ] **Step 4: Wire categories + cards in composition**
+
+In `src/infra/composition.ts`, change the installments use-case construction:
+
+```ts
+    installments: makeInstallmentUseCases({
+      installments: repositories.installments,
+      categories: repositories.categories,
+      cards: repositories.cards,
+    }),
+```
+
+- [ ] **Step 5: Run; confirm the `list` test passes**
+
+Run: `npx tsx --test test/installments.test.ts`
+Expected: the `use-case list` test passes; the `update rejects unknown category` test still fails (needs the controller — Task 4).
+
+- [ ] **Step 6: Typecheck + commit**
+
+Run: `npm run typecheck`
+```bash
+git add src/application/use-cases/installments.ts src/infra/composition.ts test/installments.test.ts
+git commit -m "feat(installments): list + update use-cases with reference checks"
+```
+
+---
+
+### Task 4: HTTP — `GET /` overview and `PUT /:id` edit
+
+**Files:**
+- Create: `src/adapters/http/schemas/installments.ts`
+- Modify: `src/adapters/http/controllers/installmentGroups.ts`
+- Test: `test/installments.test.ts` (append)
+
+**Interfaces:**
+- Consumes: `InstallmentUseCases.list`, `.update`; `parse()`; `zPositiveInt`, `zMonth` from `schemas/common`.
+- Produces: `GET /api/installment-groups?month=YYYY-MM` → `InstallmentProgress[]`; `PUT /api/installment-groups/:id` → `204`.
+
+- [ ] **Step 1: Write the failing API tests**
+
+```ts
+test('GET /api/installment-groups returns progress rows', async () => {
+  const ctx = makeTestDb();
+  const app = createApp(ctx.db);
+  await request(app).post('/api/transactions').send({ category_id: ctx.categoryId, card_id: ctx.cardId,
+    description: 'Avianca', installment_total_cents: 60000, installment_count: 6, first_month: '2026-06' }).expect(201);
+  const res = await request(app).get('/api/installment-groups?month=2026-08').expect(200);
+  assert.equal(res.body.length, 1);
+  assert.equal(res.body[0].remaining_count, 3);
+  assert.equal(res.body[0].monthly_cents, 10000);
+});
+
+test('PUT /api/installment-groups/:id re-expands the schedule', async () => {
+  const ctx = makeTestDb();
+  const app = createApp(ctx.db);
+  const made = await request(app).post('/api/transactions').send({ category_id: ctx.categoryId,
+    card_id: ctx.cardId, description: 'TV', installment_total_cents: 60000, installment_count: 6,
+    first_month: '2026-06' }).expect(201);
+  await request(app).put(`/api/installment-groups/${made.body.installment_group_id}`).send({
+    category_id: ctx.categoryId, card_id: ctx.cardId, description: 'TV',
+    total_cents: 30000, count: 3, first_month: '2026-07',
+  }).expect(204);
+  const n = ctx.db.prepare('SELECT COUNT(*) n FROM transactions WHERE installment_group_id=?')
+    .get(made.body.installment_group_id).n;
+  assert.equal(n, 3);
+});
+
+test('PUT with a bad month returns 400', async () => {
+  const ctx = makeTestDb();
+  const app = createApp(ctx.db);
+  const made = await request(app).post('/api/transactions').send({ category_id: ctx.categoryId,
+    card_id: ctx.cardId, description: 'TV', installment_total_cents: 1200, installment_count: 2,
+    first_month: '2026-06' }).expect(201);
+  await request(app).put(`/api/installment-groups/${made.body.installment_group_id}`).send({
+    category_id: ctx.categoryId, card_id: ctx.cardId, total_cents: 1200, count: 2, first_month: 'June',
+  }).expect(400);
+});
+```
+
+- [ ] **Step 2: Run; confirm fail**
+
+Run: `npx tsx --test test/installments.test.ts`
+Expected: FAIL — `GET /api/installment-groups` 404s (no route) and PUT 404s.
+
+- [ ] **Step 3: Write the schema**
+
+Create `src/adapters/http/schemas/installments.ts`:
+
+```ts
+import { z } from 'zod';
+import { zMonth, zPositiveInt } from './common';
+
+export const updateInstallmentSchema = z.object({
+  category_id: zPositiveInt('category_id must be a positive integer'),
+  card_id: zPositiveInt('card_id must be a positive integer'),
+  total_cents: zPositiveInt('total_cents must be a positive integer'),
+  count: zPositiveInt('count must be a positive integer'),
+  first_month: zMonth('first_month must be YYYY-MM'),
+});
+```
+
+- [ ] **Step 4: Extend the controller**
+
+Replace `src/adapters/http/controllers/installmentGroups.ts` with:
+
+```ts
+import express from 'express';
+import { parse } from '../validate';
+import { updateInstallmentSchema } from '../schemas/installments';
+import type { makeInstallmentUseCases } from '../../../application/use-cases/installments';
+
+type InstallmentUseCases = ReturnType<typeof makeInstallmentUseCases>;
+
+export function makeInstallmentGroupsController(uc: InstallmentUseCases): express.Router {
+  const router = express.Router();
+
+  router.get('/', (req, res) => {
+    const { MONTH_RE } = require('../schemas/common');
+    const q = req.query.month;
+    const month = (typeof q === 'string' && MONTH_RE.test(q))
+      ? q : new Date().toISOString().slice(0, 7);
+    res.json(uc.list(month));
+  });
+
+  router.put('/:id', (req, res) => {
+    const body = parse(updateInstallmentSchema, req.body);
+    uc.update(Number(req.params.id), { ...body, description: req.body.description ?? '' });
+    res.status(204).end();
+  });
+
+  router.delete('/:id', (req, res) => {
+    uc.remove(Number(req.params.id));
+    res.status(204).end();
+  });
+
+  return router;
+}
+```
+
+(Replace the inline `require` with a top `import { MONTH_RE } from '../schemas/common';` if you prefer — keep consistent with the file's import style.)
+
+- [ ] **Step 5: Run installments + app tests; confirm pass**
+
+Run: `npx tsx --test test/installments.test.ts test/app.test.ts`
+Expected: PASS, including the Task 3 "update rejects unknown category 400" test.
+
+- [ ] **Step 6: Full suite + coverage + commit**
+
+Run: `npm run coverage`
+Expected: pass, ≥80%.
+```bash
+git add src/adapters/http/schemas/installments.ts src/adapters/http/controllers/installmentGroups.ts test/installments.test.ts
+git commit -m "feat(installments): GET overview + PUT edit endpoints"
+```
+
+---
+
+### Task 5: Frontend — the Parcelas page
+
+**Files:**
+- Create: `public/parcelas.html`
+- Create: `public/js/parcelas.js`
+- Modify: `public/js/chrome.js:1-7` (add nav item)
+- Test: `test/parcelasRender.test.ts` (new)
+
+**Interfaces:**
+- Consumes: `api` (`api.js`), `formatBRL`/`esc` (`format.js`), `mountChrome` (`chrome.js`).
+- Produces: pure `renderGroups(rows: InstallmentProgress[]): string`.
+
+- [ ] **Step 1: Write the failing render test**
+
+Create `test/parcelasRender.test.ts`:
+
+```ts
+const { test } = require('node:test');
+const assert = require('node:assert');
+
+const row = {
+  id: 1, description: 'Avianca', category_name: 'Viagens', card_name: 'Nubank',
+  total_cents: 60000, total_count: 6, paid_count: 3, remaining_count: 3,
+  paid_cents: 30000, remaining_cents: 30000, monthly_cents: 10000, next_month: '2026-09',
+};
+
+test('renderGroups shows progress, monthly and remaining', async () => {
+  const { renderGroups } = await import('../public/js/parcelas.js');
+  const html = renderGroups([row]);
+  assert.match(html, /Avianca/);
+  assert.match(html, /Viagens/);
+  assert.match(html, /3\/6/);             // parcelas paid/total
+  assert.match(html, /R\$ 100,00/);       // monthly
+  assert.match(html, /R\$ 300,00/);       // remaining balance
+  assert.match(html, /2026-09/);          // next charge
+  assert.match(html, /data-edit="1"/);
+  assert.match(html, /data-del="1"/);
+});
+
+test('renderGroups escapes the description', async () => {
+  const { renderGroups } = await import('../public/js/parcelas.js');
+  const html = renderGroups([{ ...row, description: '<x>' }]);
+  assert.doesNotMatch(html, /<x>/);
+  assert.match(html, /&lt;x&gt;/);
+});
+
+test('renderGroups shows an empty state', async () => {
+  const { renderGroups } = await import('../public/js/parcelas.js');
+  assert.match(renderGroups([]), /No installment/);
+});
+```
+
+- [ ] **Step 2: Run; confirm fail**
+
+Run: `npx tsx --test test/parcelasRender.test.ts`
+Expected: FAIL — cannot resolve `../public/js/parcelas.js`.
+
+- [ ] **Step 3: Write `public/js/parcelas.js`**
+
+```js
+import { api, showError } from './api.js';
+import { formatBRL, esc, currentMonth } from './format.js';
+import { mountChrome } from './chrome.js';
+
+const $ = id => document.getElementById(id);
+
+export function renderGroups(rows) {
+  if (!rows.length) {
+    return `<p class="paper-card text-ink-mut">No installment purchases yet.</p>`;
+  }
+  return rows.map(r => `
+    <div class="paper-card" data-row="${r.id}">
+      <div class="flex items-start justify-between gap-4">
+        <div>
+          <div class="font-semibold">${esc(r.description) || 'Installment'}</div>
+          <div class="text-xs text-ink-mut mt-0.5">${esc(r.category_name)} · ${esc(r.card_name)}</div>
+        </div>
+        <span class="tag tag-gold">${r.paid_count}/${r.total_count}</span>
+      </div>
+      <div class="mt-3 grid grid-cols-3 gap-3 text-sm">
+        <div><div class="text-ink-mut text-xs">Monthly</div><div class="font-mono">${formatBRL(r.monthly_cents)}</div></div>
+        <div><div class="text-ink-mut text-xs">Remaining</div><div class="font-mono">${formatBRL(r.remaining_cents)}</div></div>
+        <div><div class="text-ink-mut text-xs">Next</div><div class="font-mono">${r.next_month || '—'}</div></div>
+      </div>
+      <div class="mt-3 text-right">
+        <button data-edit="${r.id}" class="text-sage text-sm mr-2">Edit</button>
+        ${r.remaining_count > 0 ? `<button data-payoff="${r.id}" class="text-sage text-sm mr-2">Pay off early</button>` : ''}
+        <button data-del="${r.id}" class="text-clay text-sm">Delete</button>
+      </div>
+    </div>`).join('');
+}
+
+async function load() {
+  try {
+    const rows = await api.get(`/api/installment-groups?month=${$('month').value}`);
+    $('list').innerHTML = renderGroups(rows);
+    wire(rows);
+  } catch (e) { showError(e.message); }
+}
+
+function wire(rows) {
+  $('list').querySelectorAll('button[data-del]').forEach(b =>
+    b.addEventListener('click', async () => {
+      if (!confirm('Delete this installment group (all parcelas)?')) return;
+      try { await api.del(`/api/installment-groups/${b.dataset.del}`); load(); }
+      catch (e) { showError(e.message); }
+    }));
+  $('list').querySelectorAll('button[data-payoff]').forEach(b =>
+    b.addEventListener('click', async () => {
+      if (!confirm('Pay off early? Remaining parcelas move into this month.')) return;
+      try { await api.post(`/api/installment-groups/${b.dataset.payoff}/payoff`,
+        { month: $('month').value }); load(); }
+      catch (e) { showError(e.message); }
+    }));
+  $('list').querySelectorAll('button[data-edit]').forEach(b =>
+    b.addEventListener('click', () => startEdit(rows.find(r => r.id === Number(b.dataset.edit)))));
+}
+
+function startEdit(r) {
+  if (!r) return;
+  $('editId').value = r.id;
+  $('e_description').value = r.description;
+  $('e_total').value = (r.total_cents / 100).toFixed(2);
+  $('e_count').value = r.total_count;
+  $('e_firstMonth').value = r.first_month;
+  $('editCard').style.display = 'block';
+  $('editCard').scrollIntoView({ block: 'center' });
+}
+
+if (typeof document !== 'undefined' && document.getElementById('list')) {
+  mountChrome('/parcelas.html');
+  $('month').value = currentMonth();
+  $('month').addEventListener('change', load);
+  $('editForm').addEventListener('submit', async e => {
+    e.preventDefault();
+    try {
+      await api.put(`/api/installment-groups/${$('editId').value}`, {
+        category_id: Number($('e_category').value),
+        card_id: Number($('e_card').value),
+        description: $('e_description').value,
+        total_cents: Math.round(Number($('e_total').value) * 100),
+        count: Number($('e_count').value),
+        first_month: $('e_firstMonth').value,
+      });
+      $('editCard').style.display = 'none';
+      load();
+    } catch (err) { showError(err.message); }
+  });
+  // populate category/card selects in the edit form
+  Promise.all([api.get('/api/categories'), api.get('/api/cards')]).then(([cats, cards]) => {
+    $('e_category').innerHTML = cats.filter(c => c.active).map(c => `<option value="${c.id}">${esc(c.name)}</option>`).join('');
+    $('e_card').innerHTML = cards.filter(c => c.active).map(c => `<option value="${c.id}">${esc(c.name)}</option>`).join('');
+  }).catch(e => showError(e.message));
+  load();
+}
+```
+
+- [ ] **Step 4: Run the render test; confirm pass**
+
+Run: `npx tsx --test test/parcelasRender.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Create `public/parcelas.html`**
+
+Copy the shell of `public/transactions.html` (same `<head>`, fonts, `app.css`, `<div id="nav">`, Chart.js not needed). Body skeleton:
+
+```html
+<main class="max-w-5xl mx-auto px-6 py-8">
+  <div class="flex items-center justify-between mb-6">
+    <h1 class="font-display text-3xl">Parcelas</h1>
+    <input type="month" id="month" class="rounded border border-line bg-card px-3 py-2" />
+  </div>
+  <div id="list" class="space-y-4"></div>
+
+  <div id="editCard" class="paper-card mt-8" style="display:none">
+    <h2 class="font-display text-xl mb-4">Edit installment</h2>
+    <form id="editForm" class="grid gap-3 md:grid-cols-2">
+      <input type="hidden" id="editId" />
+      <label class="block">Description <input id="e_description" class="w-full rounded border border-line px-2 py-1" /></label>
+      <label class="block">Category <select id="e_category" class="w-full rounded border border-line px-2 py-1"></select></label>
+      <label class="block">Card <select id="e_card" class="w-full rounded border border-line px-2 py-1"></select></label>
+      <label class="block">Total (R$) <input id="e_total" type="number" step="0.01" class="w-full rounded border border-line px-2 py-1" /></label>
+      <label class="block">Parcelas <input id="e_count" type="number" min="1" class="w-full rounded border border-line px-2 py-1" /></label>
+      <label class="block">First month <input id="e_firstMonth" type="month" class="w-full rounded border border-line px-2 py-1" /></label>
+      <div class="md:col-span-2 text-right"><button class="btn-primary">Save</button></div>
+    </form>
+  </div>
+</main>
+<script type="module" src="/js/parcelas.js"></script>
+```
+
+- [ ] **Step 6: Add the nav item**
+
+In `public/js/chrome.js`, add to `NAV_ITEMS` after Transactions:
+
+```js
+  { href: '/parcelas.html', label: 'Parcelas', route: '/parcelas.html' },
+```
+
+- [ ] **Step 7: Update the nav test if present**
+
+Run: `grep -rn "NAV_ITEMS\|renderNav" test/`
+If `test/chrome.test.ts` asserts the item count or list, update it to include `Parcelas`. Run: `npx tsx --test test/chrome.test.ts` → PASS.
+
+- [ ] **Step 8: Manual smoke**
+
+Run: `npm start` → open `http://localhost:3000/parcelas.html`, create an installment on Transactions, confirm it appears with the right paid/left and that Edit re-expands. (Then stop the server.)
+
+- [ ] **Step 9: Full suite + commit**
+
+Run: `npm run coverage`
+```bash
+git add public/parcelas.html public/js/parcelas.js public/js/chrome.js test/parcelasRender.test.ts test/chrome.test.ts
+git commit -m "feat(installments): Parcelas overview page with inline edit"
+```
+
+---
+
+### Task 6: Pay off early
+
+**Files:**
+- Modify: `src/domain/ports/index.ts` (`InstallmentRepository.payOffEarly`)
+- Modify: `src/infra/repositories/installments.ts`
+- Modify: `src/application/use-cases/installments.ts` (`payOff`)
+- Modify: `src/adapters/http/controllers/installmentGroups.ts` (`POST /:id/payoff`)
+- Test: `test/installments.test.ts` (append)
+
+**Interfaces:**
+- Produces: `InstallmentRepository.payOffEarly(id: number, asOfMonth: string): void` (throws `AppError(404)` if absent, `AppError(400)` if nothing to pay off); use-case `payOff(id, asOfMonth)`; `POST /api/installment-groups/:id/payoff` body `{ month }` → `204`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+test('payOffEarly collapses future parcelas into asOf month', () => {
+  const ctx = makeTestDb();
+  const repo = makeInstallmentRepository(ctx.db);
+  const id = repo.createPurchase({ category_id: ctx.categoryId, card_id: ctx.cardId,
+    description: 'TV', total_cents: 60000, count: 6, first_month: '2026-06' });
+  repo.payOffEarly(id, '2026-08');
+  const rows = repo.listWithProgress('2026-08');
+  assert.equal(rows[0].remaining_count, 0);
+  assert.equal(rows[0].paid_cents, 60000);
+  // August now carries June..Aug parcelas plus the 3 collapsed ones.
+  const aug = ctx.db.prepare(
+    "SELECT COALESCE(SUM(amount_cents),0) s FROM transactions WHERE installment_group_id=? AND strftime('%Y-%m',date)='2026-08'").get(id).s;
+  assert.equal(aug, 40000); // Aug parcela 10000 + Sep/Oct/Nov 30000 moved in
+});
+
+test('payOffEarly with nothing left throws 400', () => {
+  const ctx = makeTestDb();
+  const repo = makeInstallmentRepository(ctx.db);
+  const id = repo.createPurchase({ category_id: ctx.categoryId, card_id: ctx.cardId,
+    description: 'TV', total_cents: 1200, count: 2, first_month: '2026-06' });
+  assert.throws(() => repo.payOffEarly(id, '2027-01'), (e) => e.status === 400);
+});
+```
+
+- [ ] **Step 2: Run; confirm fail**
+
+Run: `npx tsx --test test/installments.test.ts`
+Expected: FAIL — `repo.payOffEarly is not a function`.
+
+- [ ] **Step 3: Add the port method + implementation**
+
+Port (`InstallmentRepository`):
+
+```ts
+  payOffEarly(id: number, asOfMonth: string): void; // re-date remaining parcelas to asOf; 404/400
+```
+
+Repository:
+
+```ts
+    payOffEarly(id, asOfMonth): void {
+      const tx = db.transaction(() => {
+        const exists = db.prepare('SELECT id FROM installment_groups WHERE id=?').get(id);
+        if (!exists) throw new AppError(404, 'installment group not found');
+        const r = db.prepare(
+          `UPDATE transactions SET date=@date
+           WHERE installment_group_id=@id AND strftime('%Y-%m', date) > @asOf`,
+        ).run({ date: `${asOfMonth}-01`, id, asOf: asOfMonth });
+        if (r.changes === 0) throw new AppError(400, 'no future parcelas to pay off');
+      });
+      tx();
+    },
+```
+
+- [ ] **Step 4: Use-case + controller**
+
+Use-case `makeInstallmentUseCases` return object — add:
+
+```ts
+    payOff(id: number, asOfMonth: string): void {
+      installments.payOffEarly(id, asOfMonth);
+    },
+```
+
+Controller — add before the `delete`:
+
+```ts
+  router.post('/:id/payoff', (req, res) => {
+    const { MONTH_RE } = require('../schemas/common');
+    const m = req.body.month;
+    const month = (typeof m === 'string' && MONTH_RE.test(m)) ? m : new Date().toISOString().slice(0, 7);
+    uc.payOff(Number(req.params.id), month);
+    res.status(204).end();
+  });
+```
+
+- [ ] **Step 5: Add an API test, run, confirm pass**
+
+```ts
+test('POST /api/installment-groups/:id/payoff returns 204', async () => {
+  const ctx = makeTestDb();
+  const app = createApp(ctx.db);
+  const made = await request(app).post('/api/transactions').send({ category_id: ctx.categoryId,
+    card_id: ctx.cardId, description: 'TV', installment_total_cents: 60000, installment_count: 6,
+    first_month: '2026-06' }).expect(201);
+  await request(app).post(`/api/installment-groups/${made.body.installment_group_id}/payoff`)
+    .send({ month: '2026-08' }).expect(204);
+});
+```
+
+Run: `npm run coverage`
+Expected: PASS, ≥80%.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "feat(installments): pay off early (collapse remaining parcelas)"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** list/overview (Tasks 1,4,5), atomic edit/re-expand (Tasks 2,3,4 — the standalone Tier 2 gap), pay-off early (Task 6), BI `installment-forecast` already surfaces the monthly commitment (unchanged). The "edit a single parcela silently desyncs" risk is addressed because edit re-expands the whole group.
+- **Placeholder scan:** none — every code step has full code; HTML shell (5.5) references `transactions.html` for the boilerplate `<head>`, which exists.
+- **Type consistency:** `InstallmentProgress` defined once (Task 1) and consumed by repo (1), use-case (3), controller (4), render test (5). `update`'s param shape matches between port (Task 2), repo (Task 2), use-case `UpdateInstallmentInput` (Task 3), and schema (Task 4): `{ category_id, card_id, description?, total_cents, count, first_month }`. `payOffEarly(id, asOfMonth)` consistent across port/repo/use-case/controller.
+- **Note for executor:** the inline `require('../schemas/common')` in the controller can be hoisted to a top-level `import { MONTH_RE }`; pick whichever matches the file after Biome runs (Phase 0).

--- a/docs/superpowers/plans/2026-06-27-phase-2-quick-data-driven-wins.md
+++ b/docs/superpowers/plans/2026-06-27-phase-2-quick-data-driven-wins.md
@@ -1,0 +1,529 @@
+# Phase 2 — Quick Data-Driven Wins Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Three small, high-leverage improvements: suggest category limits from spend history, add category/card/description filters to Transactions, and give the budget meter a third "approaching" state.
+
+**Architecture:** Each is a thin vertical slice over existing services. Suggested limits add a use-case method over `ReportRepository.spendByCategoryMonth` plus a GET route and two frontend buttons. Filters extend the existing `TransactionFilter`/`buildWhere`. The three-state meter adds a small domain helper used by the dashboard use-case and reflected in the shared `ui.js` renderers.
+
+**Tech Stack:** TypeScript hexagonal, Express 5, better-sqlite3, zod, `node:test` + supertest, vanilla ESM + Tailwind.
+
+## Global Constraints
+
+(Same as Phases 0–1; repeated so this plan stands alone.)
+
+- Node 22; money in integer **cents**; months `YYYY-MM`, dates `YYYY-MM-DD`.
+- Hexagonal layering; ports in `src/domain/ports/index.ts`; errors via `AppError`.
+- Tests CommonJS `require('node:test')` in `test/*.test.ts`; `makeTestDb()` for DB, `supertest` + `createApp(ctx.db)` for API.
+- Coverage ≥80% (`npm run coverage`).
+- HTTP validation via zod + `parse()`; existence rules in use-cases.
+- Frontend render functions pure + unit-tested; DOM bootstrap follows existing pages.
+- Commit after each task.
+
+---
+
+### Task 1: Suggested limits from history (API)
+
+**Files:**
+- Modify: `src/application/use-cases/limits.ts`
+- Modify: `src/infra/composition.ts:77` (add `reports` dep)
+- Modify: `src/adapters/http/controllers/limits.ts`
+- Test: `test/crud.test.ts` (append) or new `test/limitSuggestions.test.ts`
+
+**Interfaces:**
+- Consumes: `ReportRepository.spendByCategoryMonth`, `CategoryRepository.listActive`, `addMonths` from `src/domain/services/dates`.
+- Produces: `LimitUseCases.suggestions(month: string): LimitSuggestion[]` and `GET /api/limits/suggestions?month=YYYY-MM`.
+
+```ts
+export interface LimitSuggestion { category_id: number; last_month_cents: number; avg3_cents: number; }
+```
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/limitSuggestions.test.ts`:
+
+```ts
+const { test } = require('node:test');
+const assert = require('node:assert');
+const request = require('supertest');
+const { makeTestDb } = require('./helpers');
+const { createApp } = require('../src/app');
+
+test('GET /api/limits/suggestions returns last-month and 3-month average', async () => {
+  const ctx = makeTestDb();
+  const app = createApp(ctx.db);
+  const tx = (date, cents) => request(app).post('/api/transactions')
+    .send({ date, category_id: ctx.categoryId, card_id: ctx.cardId, amount_cents: cents, description: 'x' })
+    .expect(201);
+  await tx('2026-03-10', 30000); // 3 months before June
+  await tx('2026-04-10', 60000);
+  await tx('2026-05-10', 90000); // last month before June
+  const res = await request(app).get('/api/limits/suggestions?month=2026-06').expect(200);
+  const row = res.body.find(r => r.category_id === ctx.categoryId);
+  assert.equal(row.last_month_cents, 90000);
+  assert.equal(row.avg3_cents, 60000); // (30000+60000+90000)/3
+});
+```
+
+- [ ] **Step 2: Run; confirm fail**
+
+Run: `npx tsx --test test/limitSuggestions.test.ts`
+Expected: FAIL — route 404 / not found.
+
+- [ ] **Step 3: Extend the use-case**
+
+In `src/application/use-cases/limits.ts`:
+
+```ts
+import type { LimitRepository, CategoryRepository, ReportRepository } from '../../domain/ports';
+import { addMonths } from '../../domain/services/dates';
+import { AppError } from '../../domain/errors';
+
+export interface LimitUseCaseDeps {
+  limits: LimitRepository; categories: CategoryRepository; reports: ReportRepository;
+}
+export interface LimitSuggestion { category_id: number; last_month_cents: number; avg3_cents: number; }
+```
+
+Add to the returned object:
+
+```ts
+    suggestions(month: string): LimitSuggestion[] {
+      const m1 = addMonths(month, -1);
+      const m2 = addMonths(month, -2);
+      const m3 = addMonths(month, -3);
+      return categories.listActive().map(c => {
+        const a = reports.spendByCategoryMonth(c.id, m1);
+        const b = reports.spendByCategoryMonth(c.id, m2);
+        const d = reports.spendByCategoryMonth(c.id, m3);
+        return { category_id: c.id, last_month_cents: a, avg3_cents: Math.round((a + b + d) / 3) };
+      });
+    },
+```
+
+- [ ] **Step 4: Wire `reports` in composition**
+
+In `src/infra/composition.ts`:
+
+```ts
+    limits: makeLimitUseCases({
+      limits: repositories.limits, categories: repositories.categories, reports: repositories.reports,
+    }),
+```
+
+- [ ] **Step 5: Add the route**
+
+In `src/adapters/http/controllers/limits.ts`, add **before** `router.get('/')`:
+
+```ts
+  router.get('/suggestions', (req, res) => {
+    const { month } = parse(monthQuerySchema, req.query);
+    res.json(uc.suggestions(month));
+  });
+```
+
+- [ ] **Step 6: Run; confirm pass**
+
+Run: `npx tsx --test test/limitSuggestions.test.ts`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/application/use-cases/limits.ts src/infra/composition.ts src/adapters/http/controllers/limits.ts test/limitSuggestions.test.ts
+git commit -m "feat(limits): suggest limits from last-month and 3-month-average spend"
+```
+
+---
+
+### Task 2: Suggested-limits buttons (Settings + Setup)
+
+**Files:**
+- Modify: `public/settings.html` (two buttons above `#limits`)
+- Modify: `public/js/settings.js`
+- Modify: `public/setup.html` (two buttons in the limits step)
+- Modify: `public/js/setup.js`
+
+**Interfaces:**
+- Consumes: `GET /api/limits/suggestions?month=`.
+- Produces: clicking a button fills every `input[data-cat]` with the suggested value. On Settings it dispatches `change` so the existing listener persists; on Setup it only fills + re-runs allocation (Setup persists on finish).
+
+- [ ] **Step 1: Add buttons to `settings.html`**
+
+Just above the `<table>`/`#limits` container:
+
+```html
+<div class="flex gap-2 mb-3">
+  <button id="useLastMonth" class="btn-ghost text-sm">Use last month</button>
+  <button id="useAvg3" class="btn-ghost text-sm">Use 3-month average</button>
+</div>
+```
+
+- [ ] **Step 2: Wire them in `settings.js`**
+
+Add a helper and listeners (inside the `if (typeof document …)` bootstrap, after `wireLimitInputs` is available):
+
+```js
+async function applySuggestions(field) {
+  try {
+    const sugg = await api.get(`/api/limits/suggestions?month=${$('month').value}`);
+    const byCat = new Map(sugg.map(s => [s.category_id, s[field]]));
+    $('limits').querySelectorAll('input[data-cat]').forEach(inp => {
+      const v = byCat.get(Number(inp.dataset.cat));
+      if (v !== undefined) { inp.value = (v / 100).toFixed(2); inp.dispatchEvent(new Event('change')); }
+    });
+    updateAllocation();
+  } catch (e) { showError(e.message); }
+}
+$('useLastMonth').addEventListener('click', () => applySuggestions('last_month_cents'));
+$('useAvg3').addEventListener('click', () => applySuggestions('avg3_cents'));
+```
+
+- [ ] **Step 3: Add buttons + wiring to Setup**
+
+In `public/setup.html`, inside the limits step, add the same two buttons with ids `setupUseLastMonth` / `setupUseAvg3`. In `public/js/setup.js`, inside the bootstrap, add:
+
+```js
+async function applySuggestions(field) {
+  try {
+    const sugg = await api.get(`/api/limits/suggestions?month=${month}`);
+    const byCat = new Map(sugg.map(s => [s.category_id, s[field]]));
+    $('limits').querySelectorAll('input[data-cat]').forEach(inp => {
+      const v = byCat.get(Number(inp.dataset.cat));
+      if (v !== undefined) inp.value = (v / 100).toFixed(2);
+    });
+    updateAllocation();
+  } catch (e) { showError(e.message); }
+}
+$('setupUseLastMonth').addEventListener('click', () => applySuggestions('last_month_cents'));
+$('setupUseAvg3').addEventListener('click', () => applySuggestions('avg3_cents'));
+```
+
+- [ ] **Step 4: Manual smoke**
+
+Run: `npm start`; on Settings, enter a couple of past-month transactions first, then click "Use last month" and confirm inputs fill and persist (reload shows them). Stop the server.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add public/settings.html public/js/settings.js public/setup.html public/js/setup.js
+git commit -m "feat(limits): one-click suggested limits in Settings and Setup"
+```
+
+---
+
+### Task 3: Transaction filters — category, card, description search (API)
+
+**Files:**
+- Modify: `src/domain/ports/index.ts:34` (`TransactionFilter.q`)
+- Modify: `src/infra/repositories/transactions.ts:5-12` (`buildWhere`)
+- Modify: `src/application/use-cases/transactions.ts:45-48` (`list` passes `q`)
+- Modify: `src/adapters/http/controllers/transactions.ts:15-39` (parse `q`)
+- Test: `test/transactions.test.ts` (append)
+
+**Interfaces:**
+- Produces: `GET /api/transactions?q=<text>` filters by `description LIKE %text%`; `category_id` and `card_id` already filter (repo + controller support them).
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+test('GET /api/transactions filters by description q', async () => {
+  const ctx = makeTestDb();
+  const app = createApp(ctx.db);
+  const add = d => request(app).post('/api/transactions')
+    .send({ date: '2026-06-01', category_id: ctx.categoryId, card_id: ctx.cardId, amount_cents: 100, description: d })
+    .expect(201);
+  await add('Coffee at Starbucks');
+  await add('Groceries');
+  const res = await request(app).get('/api/transactions?q=coffee').expect(200);
+  assert.equal(res.body.length, 1);
+  assert.match(res.body[0].description, /Coffee/);
+});
+```
+
+- [ ] **Step 2: Run; confirm fail**
+
+Run: `npx tsx --test test/transactions.test.ts`
+Expected: FAIL — both rows returned (q ignored).
+
+- [ ] **Step 3: Add `q` to the filter type**
+
+In `src/domain/ports/index.ts`:
+
+```ts
+export interface TransactionFilter { month?: string; categoryId?: number; cardId?: number; q?: string; }
+```
+
+- [ ] **Step 4: Extend `buildWhere`**
+
+In `src/infra/repositories/transactions.ts`, inside `buildWhere`, before the `return`:
+
+```ts
+  if (f.q !== undefined && f.q !== '') { where.push('description LIKE ?'); args.push(`%${f.q}%`); }
+```
+
+- [ ] **Step 5: Pass `q` through the use-case**
+
+In `src/application/use-cases/transactions.ts` `list`:
+
+```ts
+    list(page: TransactionPage): { total: number; items: Transaction[] } {
+      const filter = { month: page.month, categoryId: page.categoryId, cardId: page.cardId, q: page.q };
+      return { total: transactions.count(filter), items: transactions.list(page) };
+    },
+```
+
+- [ ] **Step 6: Parse `q` in the controller**
+
+In `src/adapters/http/controllers/transactions.ts` GET handler, after the `card_id` line:
+
+```ts
+    if (req.query.q !== undefined) page.q = String(req.query.q);
+```
+
+- [ ] **Step 7: Run; confirm pass + coverage**
+
+Run: `npm run coverage`
+Expected: PASS, ≥80%.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/domain/ports/index.ts src/infra/repositories/transactions.ts src/application/use-cases/transactions.ts src/adapters/http/controllers/transactions.ts test/transactions.test.ts
+git commit -m "feat(transactions): description search filter (q)"
+```
+
+---
+
+### Task 4: Transaction filters — frontend controls
+
+**Files:**
+- Modify: `public/transactions.html` (filter row)
+- Modify: `public/js/transactions.js`
+
+**Interfaces:**
+- Consumes: `/api/categories`, `/api/cards`, `GET /api/transactions?...&category_id=&card_id=&q=`.
+- Produces: category/card dropdowns (with an "All" option) and a search box that re-query on change.
+
+- [ ] **Step 1: Add controls to `transactions.html`**
+
+Near the existing month input:
+
+```html
+<select id="filterCategory" class="rounded border border-line bg-card px-3 py-2"><option value="">All categories</option></select>
+<select id="filterCard" class="rounded border border-line bg-card px-3 py-2"><option value="">All cards</option></select>
+<input id="search" type="search" placeholder="Search description" class="rounded border border-line bg-card px-3 py-2" />
+```
+
+- [ ] **Step 2: Populate the filter dropdowns**
+
+In `transactions.js` `loadSelectors`, after populating the form selects, also fill the filters (keep the leading "All" option):
+
+```js
+  const opt = c => `<option value="${c.id}">${esc(c.name)}</option>`;
+  $('filterCategory').insertAdjacentHTML('beforeend', cats.filter(c => c.active).map(opt).join(''));
+  $('filterCard').insertAdjacentHTML('beforeend', cards.filter(c => c.active).map(opt).join(''));
+```
+
+(Add `esc` to the `./format.js` import if Phase 0 hasn't already.)
+
+- [ ] **Step 3: Include filters in the query**
+
+In `loadList`, build the URL from all controls:
+
+```js
+    const qs = new URLSearchParams({ month: $('month').value, limit: String(perPage), offset: String(offset) });
+    if ($('filterCategory').value) qs.set('category_id', $('filterCategory').value);
+    if ($('filterCard').value) qs.set('card_id', $('filterCard').value);
+    if ($('search').value.trim()) qs.set('q', $('search').value.trim());
+    const { items: rows, total } = await getPage(`/api/transactions?${qs}`);
+```
+
+- [ ] **Step 4: Re-query on control change**
+
+In the bootstrap, add:
+
+```js
+  ['filterCategory', 'filterCard'].forEach(id => $(id).addEventListener('change', () => { page = 1; loadList(); }));
+  $('search').addEventListener('input', () => { page = 1; loadList(); });
+```
+
+- [ ] **Step 5: Manual smoke**
+
+Run: `npm start`; add a few transactions, then filter by category, by card, and by a search term. Stop the server.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add public/transactions.html public/js/transactions.js
+git commit -m "feat(transactions): category/card/search filters on the page"
+```
+
+---
+
+### Task 5: Three-state budget meter (domain helper + dashboard)
+
+**Files:**
+- Create: `src/domain/services/budget.ts`
+- Modify: `src/application/use-cases/dashboard.ts:44` (use the helper)
+- Test: `test/budget.test.ts` (append — note this is a frontend-helper test today; create `test/budgetStatus.test.ts` for the domain helper)
+- Modify: `test/dashboard.test.ts` (adjust any status assertions in the 80–100% band)
+
+**Interfaces:**
+- Produces: `budgetStatus(spentCents: number, limitCents: number, approachAt?: number): 'ok' | 'approaching' | 'over'`. The dashboard payload's per-category `status` now has three values.
+
+- [ ] **Step 1: Write the failing domain test**
+
+Create `test/budgetStatus.test.ts`:
+
+```ts
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { budgetStatus } = require('../src/domain/services/budget');
+
+test('budgetStatus is over above limit, approaching from 80%, else ok', () => {
+  assert.equal(budgetStatus(101, 100), 'over');
+  assert.equal(budgetStatus(100, 100), 'approaching'); // at the limit
+  assert.equal(budgetStatus(80, 100), 'approaching');
+  assert.equal(budgetStatus(79, 100), 'ok');
+  assert.equal(budgetStatus(50, 0), 'ok');             // no limit set
+});
+```
+
+- [ ] **Step 2: Run; confirm fail**
+
+Run: `npx tsx --test test/budgetStatus.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the helper**
+
+Create `src/domain/services/budget.ts`:
+
+```ts
+export type BudgetStatus = 'ok' | 'approaching' | 'over';
+
+export function budgetStatus(spentCents: number, limitCents: number, approachAt = 0.8): BudgetStatus {
+  if (limitCents > 0 && spentCents > limitCents) return 'over';
+  if (limitCents > 0 && spentCents >= limitCents * approachAt) return 'approaching';
+  return 'ok';
+}
+```
+
+- [ ] **Step 4: Use it in the dashboard use-case**
+
+In `src/application/use-cases/dashboard.ts`, import and replace the inline status:
+
+```ts
+import { budgetStatus } from '../../domain/services/budget';
+```
+```ts
+          status: budgetStatus(effective_spent_cents, limit_cents),
+```
+
+- [ ] **Step 5: Fix dashboard tests in the new band**
+
+Run: `npx tsx --test test/dashboard.test.ts`
+If a case with spend in 80–100% of limit previously asserted `'ok'`, update it to `'approaching'`. (Cases that are clearly under 80% or over 100% are unchanged.) Re-run → PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/domain/services/budget.ts src/application/use-cases/dashboard.ts test/budgetStatus.test.ts test/dashboard.test.ts
+git commit -m "feat(budget): three-state status (ok/approaching/over) in dashboard"
+```
+
+---
+
+### Task 6: Three-state rendering (frontend)
+
+**Files:**
+- Modify: `public/js/ui.js:7-17` (`meterBar`, `statusPill`)
+- Modify: `public/css/tailwind.src.css` (add `.pill-warn`, `.meter-fill.approaching`)
+- Test: `test/ui.test.ts` (append); `test/dashboardRender.test.ts` (add an approaching case)
+
+**Interfaces:**
+- Consumes: `status` of `'ok' | 'approaching' | 'over'`.
+- Produces: `meterBar` renders an `approaching` fill; `statusPill` renders a "Close" warn pill.
+
+- [ ] **Step 1: Write the failing render tests**
+
+Append to `test/ui.test.ts`:
+
+```ts
+test('statusPill renders a warn pill when approaching', async () => {
+  const { statusPill } = await import('../public/js/ui.js');
+  assert.match(statusPill('approaching'), /pill-warn/);
+  assert.match(statusPill('approaching'), /Close/);
+});
+
+test('meterBar marks the approaching fill', async () => {
+  const { meterBar } = await import('../public/js/ui.js');
+  assert.match(meterBar(85, 100, 'approaching'), /meter-fill approaching/);
+  assert.doesNotMatch(meterBar(85, 100, 'approaching'), /over/);
+});
+```
+
+- [ ] **Step 2: Run; confirm fail**
+
+Run: `npx tsx --test test/ui.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Update `ui.js`**
+
+```js
+export function meterBar(spentCents, limitCents, status) {
+  const pct = limitCents > 0 ? Math.min(100, Math.round((spentCents / limitCents) * 100)) : 0;
+  const over = status === 'over' || (limitCents > 0 && spentCents > limitCents);
+  const cls = over ? ' over' : status === 'approaching' ? ' approaching' : '';
+  return `<div class="meter"><div class="meter-fill${cls}" style="width:${pct}%"></div></div>`;
+}
+
+export function statusPill(status) {
+  if (status === 'over') return `<span class="pill pill-over">Over</span>`;
+  if (status === 'approaching') return `<span class="pill pill-warn">Close</span>`;
+  return `<span class="pill pill-ok">OK</span>`;
+}
+```
+
+- [ ] **Step 4: Add the CSS variants**
+
+Run: `grep -n "pill-over\|meter-fill" public/css/tailwind.src.css`
+Find the existing `.pill-over` and `.meter-fill.over` blocks and add gold-toned siblings next to them, e.g.:
+
+```css
+.pill-warn { @apply bg-gold/15 text-gold-700; }   /* mirror .pill-over, gold instead of clay */
+.meter-fill.approaching { @apply bg-gold; }        /* mirror .meter-fill.over */
+```
+
+(Match the exact utility classes the existing `.pill-over` / `.meter-fill.over` use — substitute the gold palette token. Confirm the gold token names from the surrounding file.)
+
+- [ ] **Step 5: Rebuild CSS**
+
+Run: `npm run build:css`
+Expected: regenerates `public/css/app.css` including the new classes.
+
+- [ ] **Step 6: Run render tests; confirm pass**
+
+Run: `npx tsx --test test/ui.test.ts test/dashboardRender.test.ts`
+Expected: PASS.
+
+- [ ] **Step 7: Manual smoke**
+
+Run: `npm start`; set a category limit and add spend at ~85% of it; confirm the meter is gold and the pill says "Close". Stop the server.
+
+- [ ] **Step 8: Full suite + commit**
+
+Run: `npm run coverage`
+```bash
+git add public/js/ui.js public/css/tailwind.src.css test/ui.test.ts test/dashboardRender.test.ts
+git commit -m "feat(ui): three-state meter and warn pill"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** suggested limits API + UI (Tasks 1–2), transaction filters API + UI (Tasks 3–4), three-state meter domain+dashboard+render (Tasks 5–6). All three Phase-2 items covered.
+- **Placeholder scan:** the only soft spot is the CSS (Task 6.4) — handled by a grep step that locates the exact existing classes to mirror, rather than guessing utility names.
+- **Type consistency:** `LimitSuggestion` defined in Task 1 and consumed by the frontend in Task 2 via field names `last_month_cents` / `avg3_cents`. `TransactionFilter.q` flows port→repo→use-case→controller with the same name. `budgetStatus` signature is identical in helper (Task 5) and tests (Tasks 5–6); status string union `'ok'|'approaching'|'over'` is the same on backend (Task 5) and frontend (Task 6).
+- **Coupling note:** `category.js` `renderSummary` and the simulate use-case still compute a two-state status independently. Adopting `budgetStatus`/the three-state pills there is a trivial follow-up but is intentionally out of this phase's scope to keep tasks isolated.

--- a/docs/superpowers/plans/2026-06-27-phase-3-recurring-and-savings-history.md
+++ b/docs/superpowers/plans/2026-06-27-phase-3-recurring-and-savings-history.md
@@ -1,0 +1,812 @@
+# Phase 3 — Recurring Transactions & Savings History Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** (a) Let the user define recurring/subscription templates and one-click materialize each month's charges (flagging amount changes); (b) add a "Savings over time" chart — the missing savings-side of BI.
+
+**Architecture:** Recurring is a new vertical slice: migration `004` (a `recurring_templates` table + a `recurring_template_id` column on `transactions` for idempotent dedup), a `RecurringRepository`, a use-case with a `materialize(month)` operation, a `/api/recurring` controller, and a `public/recurring.html` page. Savings history extends the existing BI use-case/controller and the `bi.html` chart grid, reusing the `lineChart` contract.
+
+**Tech Stack:** TypeScript hexagonal, Express 5, better-sqlite3, zod, `node:test` + supertest, vanilla ESM + Chart.js.
+
+## Global Constraints
+
+(Same as Phases 0–2; repeated so this plan stands alone.)
+
+- Node 22; money in integer **cents**; months `YYYY-MM`, dates `YYYY-MM-DD`.
+- Hexagonal layering; ports in `src/domain/ports/index.ts`; entities in `src/domain/entities/index.ts`; errors via `AppError`.
+- Migrations live in `migrations/NNN_name.sql`; the runner applies unapplied `.sql` in sorted order and records them in `schema_migrations`. `makeTestDb()` runs **every** migration except `002_seed.sql`, so a new `004` migration is active in tests.
+- Tests CommonJS `require('node:test')`; `makeTestDb()` for DB, `supertest` + `createApp(ctx.db)` for API; coverage ≥80% (`npm run coverage`).
+- HTTP validation via zod + `parse()`; existence rules in use-cases.
+- Frontend render functions pure + unit-tested; charts via `lineChart(canvasId, labels, series, onlyNonZero)` where each `series` item is `{ name, spent_cents: number[] }`.
+- Commit after each task.
+
+## Design Decisions (review before executing)
+
+1. **Materialization is manual and idempotent.** The user clicks "Materialize this month"; for each active template the app inserts one transaction for that month **only if** none already exists for that `(template, month)`. Dedup is enforced by the new `transactions.recurring_template_id` column. Re-clicking is safe.
+2. **Charge date = the template's `day_of_month`, clamped to the month length** (e.g. day 31 in February → the 28th/29th).
+3. **"Amount changed" flag** compares the template's current `amount_cents` to the most recent *prior* month's materialized charge for that template. It is informational only — it does not block or rewrite anything.
+4. **Editing a template never touches already-materialized transactions.** Past charges are real, edited like any transaction on the Transactions page. (Mirrors the per-month-limit-history principle.)
+5. **Savings history uses the current savings settings across all months.** There is no historical settings table, so income/fixed/goal are today's values applied to every month in the range. Documented in the chart subtitle. Per month: `projected_savings = income − fixed − actual_spend(month)`, plotted against a flat `goal` line.
+
+---
+
+### Task 1: Migration, entity, port, repository
+
+**Files:**
+- Create: `migrations/004_recurring.sql`
+- Modify: `src/domain/entities/index.ts` (`RecurringTemplate`)
+- Modify: `src/domain/ports/index.ts` (`RecurringRepository`)
+- Create: `src/infra/repositories/recurring.ts`
+- Test: `test/recurring.test.ts` (new)
+
+**Interfaces:**
+- Produces: `RecurringTemplate` entity and `RecurringRepository` with `list`, `listActive`, `findById`, `insert`, `update`, `deactivate`, `findChargeForMonth`, `insertCharge`, `lastChargeAmountBefore`.
+
+```ts
+// entity
+export interface RecurringTemplate {
+  id: number; description: string; category_id: number; card_id: number;
+  amount_cents: number; day_of_month: number; active: number;
+}
+```
+
+```ts
+// port
+export interface RecurringRepository {
+  list(): RecurringTemplate[];
+  listActive(): RecurringTemplate[];
+  findById(id: number): RecurringTemplate | undefined;
+  insert(t: { description: string; category_id: number; card_id: number; amount_cents: number; day_of_month: number }): RecurringTemplate;
+  update(id: number, t: { description: string; category_id: number; card_id: number; amount_cents: number; day_of_month: number; active: number }): number;
+  deactivate(id: number): number;
+  findChargeForMonth(templateId: number, month: string): boolean;
+  insertCharge(c: { template_id: number; date: string; category_id: number; card_id: number; amount_cents: number; description: string }): number;
+  lastChargeAmountBefore(templateId: number, month: string): number | null;
+}
+```
+
+- [ ] **Step 1: Write the migration**
+
+Create `migrations/004_recurring.sql`:
+
+```sql
+CREATE TABLE recurring_templates (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  description TEXT NOT NULL DEFAULT '',
+  category_id INTEGER NOT NULL REFERENCES categories(id),
+  card_id INTEGER NOT NULL REFERENCES cards(id),
+  amount_cents INTEGER NOT NULL,
+  day_of_month INTEGER NOT NULL DEFAULT 1,
+  active INTEGER NOT NULL DEFAULT 1
+);
+
+ALTER TABLE transactions ADD COLUMN recurring_template_id INTEGER REFERENCES recurring_templates(id);
+CREATE INDEX idx_tx_recurring ON transactions(recurring_template_id);
+```
+
+- [ ] **Step 2: Write the failing repository test**
+
+Create `test/recurring.test.ts`:
+
+```ts
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { makeTestDb } = require('./helpers');
+const { makeRecurringRepository } = require('../src/infra/repositories/recurring');
+
+test('insert + list round-trips a template', () => {
+  const ctx = makeTestDb();
+  const repo = makeRecurringRepository(ctx.db);
+  const t = repo.insert({ description: 'Claude', category_id: ctx.categoryId, card_id: ctx.cardId,
+    amount_cents: 10000, day_of_month: 5 });
+  assert.equal(t.description, 'Claude');
+  assert.equal(repo.list().length, 1);
+  assert.equal(repo.listActive().length, 1);
+});
+
+test('charge dedup + last-amount lookup', () => {
+  const ctx = makeTestDb();
+  const repo = makeRecurringRepository(ctx.db);
+  const t = repo.insert({ description: 'Disney', category_id: ctx.categoryId, card_id: ctx.cardId,
+    amount_cents: 4000, day_of_month: 1 });
+  assert.equal(repo.findChargeForMonth(t.id, '2026-06'), false);
+  repo.insertCharge({ template_id: t.id, date: '2026-05-01', category_id: ctx.categoryId,
+    card_id: ctx.cardId, amount_cents: 3500, description: 'Disney' });
+  assert.equal(repo.lastChargeAmountBefore(t.id, '2026-06'), 3500);
+  repo.insertCharge({ template_id: t.id, date: '2026-06-01', category_id: ctx.categoryId,
+    card_id: ctx.cardId, amount_cents: 4000, description: 'Disney' });
+  assert.equal(repo.findChargeForMonth(t.id, '2026-06'), true);
+});
+```
+
+- [ ] **Step 3: Run; confirm fail**
+
+Run: `npx tsx --test test/recurring.test.ts`
+Expected: FAIL — `makeRecurringRepository` not found.
+
+- [ ] **Step 4: Add the entity + port** (paste the blocks above into the respective files).
+
+- [ ] **Step 5: Implement the repository**
+
+Create `src/infra/repositories/recurring.ts`:
+
+```ts
+import type { Db } from '../db';
+import type { RecurringTemplate } from '../../domain/entities';
+import type { RecurringRepository } from '../../domain/ports';
+
+export function makeRecurringRepository(db: Db): RecurringRepository {
+  return {
+    list() {
+      return db.prepare('SELECT * FROM recurring_templates ORDER BY id').all() as RecurringTemplate[];
+    },
+    listActive() {
+      return db.prepare('SELECT * FROM recurring_templates WHERE active=1 ORDER BY id').all() as RecurringTemplate[];
+    },
+    findById(id) {
+      return db.prepare('SELECT * FROM recurring_templates WHERE id=?').get(id) as RecurringTemplate | undefined;
+    },
+    insert(t) {
+      const r = db.prepare(
+        `INSERT INTO recurring_templates (description, category_id, card_id, amount_cents, day_of_month)
+         VALUES (?, ?, ?, ?, ?)`,
+      ).run(t.description, t.category_id, t.card_id, t.amount_cents, t.day_of_month);
+      return db.prepare('SELECT * FROM recurring_templates WHERE id=?').get(r.lastInsertRowid) as RecurringTemplate;
+    },
+    update(id, t) {
+      return db.prepare(
+        `UPDATE recurring_templates SET description=?, category_id=?, card_id=?, amount_cents=?, day_of_month=?, active=? WHERE id=?`,
+      ).run(t.description, t.category_id, t.card_id, t.amount_cents, t.day_of_month, t.active, id).changes;
+    },
+    deactivate(id) {
+      return db.prepare('UPDATE recurring_templates SET active=0 WHERE id=?').run(id).changes;
+    },
+    findChargeForMonth(templateId, month) {
+      const row = db.prepare(
+        `SELECT 1 FROM transactions WHERE recurring_template_id=? AND strftime('%Y-%m', date)=? LIMIT 1`,
+      ).get(templateId, month);
+      return row !== undefined;
+    },
+    insertCharge(c) {
+      const r = db.prepare(
+        `INSERT INTO transactions (date, category_id, card_id, amount_cents, description, recurring_template_id)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+      ).run(c.date, c.category_id, c.card_id, c.amount_cents, c.description, c.template_id);
+      return r.lastInsertRowid as number;
+    },
+    lastChargeAmountBefore(templateId, month) {
+      const row = db.prepare(
+        `SELECT amount_cents FROM transactions
+         WHERE recurring_template_id=? AND strftime('%Y-%m', date) < ?
+         ORDER BY date DESC LIMIT 1`,
+      ).get(templateId, month) as { amount_cents: number } | undefined;
+      return row ? row.amount_cents : null;
+    },
+  };
+}
+```
+
+- [ ] **Step 6: Run; confirm pass; commit**
+
+Run: `npx tsx --test test/recurring.test.ts`
+```bash
+git add migrations/004_recurring.sql src/domain/entities/index.ts src/domain/ports/index.ts src/infra/repositories/recurring.ts test/recurring.test.ts
+git commit -m "feat(recurring): migration + repository for subscription templates"
+```
+
+---
+
+### Task 2: Date helper + use-case (CRUD + materialize) + wiring
+
+**Files:**
+- Modify: `src/domain/services/dates.ts` (`daysInMonth`, `chargeDate`)
+- Create: `src/application/use-cases/recurring.ts`
+- Modify: `src/infra/composition.ts` (repo + use-case)
+- Test: `test/dates.test.ts` (append); `test/recurring.test.ts` (append)
+
+**Interfaces:**
+- Produces: `daysInMonth(month)`, `chargeDate(month, day)`; `makeRecurringUseCases({ recurring, categories, cards })` returning `list`, `create`, `update`, `remove`, `materialize(month): MaterializeResult`.
+
+```ts
+export interface MaterializeResult {
+  created: number[];                                            // template ids charged this run
+  skipped: number[];                                           // already had a charge this month
+  changed: { template_id: number; from_cents: number; to_cents: number }[];
+}
+```
+
+- [ ] **Step 1: Write the failing date-helper test**
+
+Append to `test/dates.test.ts`:
+
+```ts
+const { daysInMonth, chargeDate } = require('../src/domain/services/dates');
+
+test('chargeDate clamps the day to the month length', () => {
+  assert.equal(chargeDate('2026-02', 31), '2026-02-28');
+  assert.equal(chargeDate('2026-06', 5), '2026-06-05');
+  assert.equal(chargeDate('2026-01', 31), '2026-01-31');
+  assert.equal(daysInMonth('2024-02'), 29); // leap year
+});
+```
+
+- [ ] **Step 2: Implement the helpers**
+
+Append to `src/domain/services/dates.ts`:
+
+```ts
+export function daysInMonth(month: string): number {
+  const [y, m] = month.split('-').map(Number);
+  return new Date(y, m, 0).getDate();
+}
+
+export function chargeDate(month: string, day: number): string {
+  const d = Math.min(Math.max(1, day), daysInMonth(month));
+  return `${month}-${String(d).padStart(2, '0')}`;
+}
+```
+
+- [ ] **Step 3: Run the date test; confirm pass**
+
+Run: `npx tsx --test test/dates.test.ts`
+Expected: PASS.
+
+- [ ] **Step 4: Write the failing materialize test**
+
+Append to `test/recurring.test.ts`:
+
+```ts
+const { makeRecurringUseCases } = require('../src/application/use-cases/recurring');
+const { makeCategoryRepository } = require('../src/infra/repositories/categories');
+const { makeCardRepository } = require('../src/infra/repositories/cards');
+
+function ucFor(ctx) {
+  return makeRecurringUseCases({
+    recurring: makeRecurringRepository(ctx.db),
+    categories: makeCategoryRepository(ctx.db),
+    cards: makeCardRepository(ctx.db),
+  });
+}
+
+test('materialize creates one charge per active template and is idempotent', () => {
+  const ctx = makeTestDb();
+  const repo = makeRecurringRepository(ctx.db);
+  const t = repo.insert({ description: 'Apple', category_id: ctx.categoryId, card_id: ctx.cardId,
+    amount_cents: 1990, day_of_month: 10 });
+  const uc = ucFor(ctx);
+  const r1 = uc.materialize('2026-06');
+  assert.deepEqual(r1.created, [t.id]);
+  const r2 = uc.materialize('2026-06');           // second run: nothing new
+  assert.deepEqual(r2.created, []);
+  assert.deepEqual(r2.skipped, [t.id]);
+  const row = ctx.db.prepare("SELECT date FROM transactions WHERE recurring_template_id=?").get(t.id);
+  assert.equal(row.date, '2026-06-10');
+});
+
+test('materialize flags an amount change vs the prior month', () => {
+  const ctx = makeTestDb();
+  const repo = makeRecurringRepository(ctx.db);
+  const t = repo.insert({ description: 'Seguro', category_id: ctx.categoryId, card_id: ctx.cardId,
+    amount_cents: 5000, day_of_month: 1 });
+  repo.insertCharge({ template_id: t.id, date: '2026-05-01', category_id: ctx.categoryId,
+    card_id: ctx.cardId, amount_cents: 4500, description: 'Seguro' });
+  const r = ucFor(ctx).materialize('2026-06');
+  assert.deepEqual(r.changed, [{ template_id: t.id, from_cents: 4500, to_cents: 5000 }]);
+});
+```
+
+- [ ] **Step 5: Implement the use-case**
+
+Create `src/application/use-cases/recurring.ts`:
+
+```ts
+import type { RecurringRepository, CategoryRepository, CardRepository } from '../../domain/ports';
+import type { RecurringTemplate } from '../../domain/entities';
+import { AppError } from '../../domain/errors';
+import { chargeDate } from '../../domain/services/dates';
+
+export interface RecurringUseCaseDeps {
+  recurring: RecurringRepository; categories: CategoryRepository; cards: CardRepository;
+}
+export interface RecurringInput {
+  description?: string; category_id: number; card_id: number; amount_cents: number; day_of_month: number;
+}
+export interface MaterializeResult {
+  created: number[]; skipped: number[];
+  changed: { template_id: number; from_cents: number; to_cents: number }[];
+}
+
+export function makeRecurringUseCases(deps: RecurringUseCaseDeps) {
+  const { recurring, categories, cards } = deps;
+  function assertRefs(categoryId: number, cardId: number): void {
+    if (!categories.findById(categoryId)) throw new AppError(400, 'category_id does not exist');
+    if (!cards.findById(cardId)) throw new AppError(400, 'card_id does not exist');
+  }
+
+  return {
+    list(): RecurringTemplate[] { return recurring.list(); },
+
+    create(input: RecurringInput): RecurringTemplate {
+      assertRefs(input.category_id, input.card_id);
+      return recurring.insert({ description: input.description ?? '', category_id: input.category_id,
+        card_id: input.card_id, amount_cents: input.amount_cents, day_of_month: input.day_of_month });
+    },
+
+    update(id: number, input: RecurringInput): RecurringTemplate {
+      assertRefs(input.category_id, input.card_id);
+      const changes = recurring.update(id, { description: input.description ?? '',
+        category_id: input.category_id, card_id: input.card_id, amount_cents: input.amount_cents,
+        day_of_month: input.day_of_month, active: 1 });
+      if (changes === 0) throw new AppError(404, 'recurring template not found');
+      return recurring.findById(id) as RecurringTemplate;
+    },
+
+    remove(id: number): void {
+      if (recurring.deactivate(id) === 0) throw new AppError(404, 'recurring template not found');
+    },
+
+    materialize(month: string): MaterializeResult {
+      const result: MaterializeResult = { created: [], skipped: [], changed: [] };
+      for (const t of recurring.listActive()) {
+        if (recurring.findChargeForMonth(t.id, month)) { result.skipped.push(t.id); continue; }
+        const last = recurring.lastChargeAmountBefore(t.id, month);
+        recurring.insertCharge({ template_id: t.id, date: chargeDate(month, t.day_of_month),
+          category_id: t.category_id, card_id: t.card_id, amount_cents: t.amount_cents,
+          description: t.description });
+        if (last !== null && last !== t.amount_cents) {
+          result.changed.push({ template_id: t.id, from_cents: last, to_cents: t.amount_cents });
+        }
+        result.created.push(t.id);
+      }
+      return result;
+    },
+  };
+}
+```
+
+- [ ] **Step 6: Wire into composition**
+
+In `src/infra/composition.ts`: import `makeRecurringRepository`, `makeRecurringUseCases`, `makeRecurringController` (controller added in Task 3); add `recurring: makeRecurringRepository(db)` to `repositories`, `recurring: makeRecurringUseCases({ recurring: repositories.recurring, categories: repositories.categories, cards: repositories.cards })` to `useCases`, and (after Task 3) `recurring: makeRecurringController(useCases.recurring)` to `controllers`; add `recurring: express.Router;` to the `Container` interface.
+
+- [ ] **Step 7: Run; confirm pass**
+
+Run: `npx tsx --test test/recurring.test.ts`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/domain/services/dates.ts src/application/use-cases/recurring.ts src/infra/composition.ts test/dates.test.ts test/recurring.test.ts
+git commit -m "feat(recurring): use-case with idempotent monthly materialize"
+```
+
+---
+
+### Task 3: HTTP controller + schema + route mount
+
+**Files:**
+- Create: `src/adapters/http/schemas/recurring.ts`
+- Create: `src/adapters/http/controllers/recurring.ts`
+- Modify: `src/app.ts:31` (mount `/api/recurring`)
+- Test: `test/recurring.test.ts` (append API cases)
+
+**Interfaces:**
+- Produces: `GET/POST /api/recurring`, `PUT/DELETE /api/recurring/:id`, `POST /api/recurring/materialize` (`{ month }` → `MaterializeResult`).
+
+- [ ] **Step 1: Write the failing API test**
+
+```ts
+const request = require('supertest');
+const { createApp } = require('../src/app');
+
+test('recurring CRUD + materialize over HTTP', async () => {
+  const ctx = makeTestDb();
+  const app = createApp(ctx.db);
+  const made = await request(app).post('/api/recurring').send({ description: 'Netflix',
+    category_id: ctx.categoryId, card_id: ctx.cardId, amount_cents: 4590, day_of_month: 15 }).expect(201);
+  assert.equal((await request(app).get('/api/recurring').expect(200)).body.length, 1);
+  const res = await request(app).post('/api/recurring/materialize').send({ month: '2026-06' }).expect(200);
+  assert.deepEqual(res.body.created, [made.body.id]);
+  await request(app).delete(`/api/recurring/${made.body.id}`).expect(204);
+  assert.equal((await request(app).get('/api/recurring').expect(200)).body.filter(t => t.active).length, 0);
+});
+
+test('POST /api/recurring with unknown card -> 400', async () => {
+  const ctx = makeTestDb();
+  const app = createApp(ctx.db);
+  await request(app).post('/api/recurring').send({ description: 'X', category_id: ctx.categoryId,
+    card_id: 99999, amount_cents: 100, day_of_month: 1 }).expect(400);
+});
+```
+
+- [ ] **Step 2: Run; confirm fail**
+
+Run: `npx tsx --test test/recurring.test.ts`
+Expected: FAIL — `/api/recurring` 404.
+
+- [ ] **Step 3: Write the schema**
+
+Create `src/adapters/http/schemas/recurring.ts`:
+
+```ts
+import { z } from 'zod';
+import { zPositiveInt } from './common';
+
+const dayOfMonth = z.custom<number>(
+  v => typeof v === 'number' && Number.isInteger(v) && v >= 1 && v <= 31,
+  { message: 'day_of_month must be an integer 1..31' });
+
+export const recurringBodySchema = z.object({
+  category_id: zPositiveInt('category_id must be a positive integer'),
+  card_id: zPositiveInt('card_id must be a positive integer'),
+  amount_cents: zPositiveInt('amount_cents must be a positive integer'),
+  day_of_month: dayOfMonth,
+});
+
+export const materializeSchema = z.object({
+  month: z.custom<string>(v => typeof v === 'string' && /^\d{4}-\d{2}$/.test(v),
+    { message: 'month must be YYYY-MM' }),
+});
+```
+
+- [ ] **Step 4: Write the controller**
+
+Create `src/adapters/http/controllers/recurring.ts`:
+
+```ts
+import express from 'express';
+import { parse } from '../validate';
+import { recurringBodySchema, materializeSchema } from '../schemas/recurring';
+import type { makeRecurringUseCases } from '../../../application/use-cases/recurring';
+
+type RecurringUseCases = ReturnType<typeof makeRecurringUseCases>;
+
+export function makeRecurringController(uc: RecurringUseCases): express.Router {
+  const router = express.Router();
+
+  router.get('/', (_req, res) => res.json(uc.list()));
+
+  router.post('/materialize', (req, res) => {
+    const { month } = parse(materializeSchema, req.body);
+    res.json(uc.materialize(month));
+  });
+
+  router.post('/', (req, res) => {
+    parse(recurringBodySchema, req.body);
+    res.status(201).json(uc.create(req.body));
+  });
+
+  router.put('/:id', (req, res) => {
+    parse(recurringBodySchema, req.body);
+    res.json(uc.update(Number(req.params.id), req.body));
+  });
+
+  router.delete('/:id', (req, res) => {
+    uc.remove(Number(req.params.id));
+    res.status(204).end();
+  });
+
+  return router;
+}
+```
+
+- [ ] **Step 5: Mount it**
+
+In `src/app.ts`, add after the simulate mount:
+
+```ts
+  app.use('/api/recurring', controllers.recurring);
+```
+
+(Plus the composition `controllers.recurring` + `Container` entry from Task 2.6.)
+
+- [ ] **Step 6: Run; confirm pass + coverage**
+
+Run: `npm run coverage`
+Expected: PASS, ≥80%.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/adapters/http/schemas/recurring.ts src/adapters/http/controllers/recurring.ts src/app.ts src/infra/composition.ts test/recurring.test.ts
+git commit -m "feat(recurring): REST endpoints + materialize"
+```
+
+---
+
+### Task 4: Recurring frontend page
+
+**Files:**
+- Create: `public/recurring.html`
+- Create: `public/js/recurring.js`
+- Modify: `public/js/chrome.js` (nav item)
+- Test: `test/recurringRender.test.ts` (new)
+
+**Interfaces:**
+- Produces: pure `renderList(rows, catName, cardName)` — but to avoid lookups, the page fetches categories/cards and passes name maps; the tested unit is `renderList(rows, names)` where `names = { cats: Map, cards: Map }`.
+
+- [ ] **Step 1: Write the failing render test**
+
+Create `test/recurringRender.test.ts`:
+
+```ts
+const { test } = require('node:test');
+const assert = require('node:assert');
+
+test('renderList shows description, amount, day and actions', async () => {
+  const { renderList } = await import('../public/js/recurring.js');
+  const names = { cats: new Map([[1, 'Assinaturas']]), cards: new Map([[2, 'Nubank']]) };
+  const html = renderList([{ id: 7, description: 'Claude', category_id: 1, card_id: 2,
+    amount_cents: 10000, day_of_month: 5, active: 1 }], names);
+  assert.match(html, /Claude/);
+  assert.match(html, /Assinaturas/);
+  assert.match(html, /R\$ 100,00/);
+  assert.match(html, /day 5/);
+  assert.match(html, /data-del="7"/);
+});
+
+test('renderList escapes the description', async () => {
+  const { renderList } = await import('../public/js/recurring.js');
+  const html = renderList([{ id: 1, description: '<x>', category_id: 1, card_id: 2,
+    amount_cents: 100, day_of_month: 1, active: 1 }], { cats: new Map(), cards: new Map() });
+  assert.doesNotMatch(html, /<x>/);
+  assert.match(html, /&lt;x&gt;/);
+});
+```
+
+- [ ] **Step 2: Run; confirm fail**
+
+Run: `npx tsx --test test/recurringRender.test.ts`
+Expected: FAIL — module missing.
+
+- [ ] **Step 3: Write `public/js/recurring.js`**
+
+```js
+import { api, showError } from './api.js';
+import { formatBRL, esc, currentMonth } from './format.js';
+import { mountChrome } from './chrome.js';
+
+const $ = id => document.getElementById(id);
+let names = { cats: new Map(), cards: new Map() };
+
+export function renderList(rows, n) {
+  if (!rows.length) return `<p class="paper-card text-ink-mut">No recurring templates yet.</p>`;
+  return rows.filter(r => r.active).map(r => `
+    <div class="paper-card flex items-center justify-between">
+      <div>
+        <div class="font-semibold">${esc(r.description) || 'Recurring'}</div>
+        <div class="text-xs text-ink-mut">${esc(n.cats.get(r.category_id) || '')} · ${esc(n.cards.get(r.card_id) || '')} · day ${r.day_of_month}</div>
+      </div>
+      <div class="text-right">
+        <div class="font-mono">${formatBRL(r.amount_cents)}</div>
+        <button data-del="${r.id}" class="text-clay text-sm">Remove</button>
+      </div>
+    </div>`).join('');
+}
+
+async function load() {
+  try {
+    const [rows, cats, cards] = await Promise.all([
+      api.get('/api/recurring'), api.get('/api/categories'), api.get('/api/cards')]);
+    names = { cats: new Map(cats.map(c => [c.id, c.name])), cards: new Map(cards.map(c => [c.id, c.name])) };
+    $('list').innerHTML = renderList(rows, names);
+    $('list').querySelectorAll('button[data-del]').forEach(b =>
+      b.addEventListener('click', async () => {
+        try { await api.del(`/api/recurring/${b.dataset.del}`); load(); } catch (e) { showError(e.message); }
+      }));
+    $('category').innerHTML = cats.filter(c => c.active).map(c => `<option value="${c.id}">${esc(c.name)}</option>`).join('');
+    $('card').innerHTML = cards.filter(c => c.active).map(c => `<option value="${c.id}">${esc(c.name)}</option>`).join('');
+  } catch (e) { showError(e.message); }
+}
+
+if (typeof document !== 'undefined' && document.getElementById('list')) {
+  mountChrome('/recurring.html');
+  $('month').value = currentMonth();
+  $('addForm').addEventListener('submit', async e => {
+    e.preventDefault();
+    try {
+      await api.post('/api/recurring', {
+        description: $('description').value, category_id: Number($('category').value),
+        card_id: Number($('card').value), amount_cents: Math.round(Number($('amount').value) * 100),
+        day_of_month: Number($('day').value),
+      });
+      $('addForm').reset(); load();
+    } catch (err) { showError(err.message); }
+  });
+  $('materialize').addEventListener('click', async () => {
+    try {
+      const r = await api.post('/api/recurring/materialize', { month: $('month').value });
+      const changed = r.changed.map(c => `${formatBRL(c.from_cents)}→${formatBRL(c.to_cents)}`).join(', ');
+      showError(`Created ${r.created.length}, skipped ${r.skipped.length}${changed ? ` · changed: ${changed}` : ''}`);
+    } catch (e) { showError(e.message); }
+  });
+  load();
+}
+```
+
+- [ ] **Step 4: Create `public/recurring.html`**
+
+Reuse the `transactions.html` shell. Body: a month input + "Materialize this month" button (`id="materialize"`), a `#list` container, and an add form (`id="addForm"`) with `description`, `category` (select), `card` (select), `amount` (number), `day` (number 1–31). Script: `<script type="module" src="/js/recurring.js"></script>`.
+
+- [ ] **Step 5: Add nav item**
+
+In `public/js/chrome.js` `NAV_ITEMS`, add `{ href: '/recurring.html', label: 'Recurring', route: '/recurring.html' }`. Update `test/chrome.test.ts` if it asserts the nav set; re-run it.
+
+- [ ] **Step 6: Run render test + manual smoke**
+
+Run: `npx tsx --test test/recurringRender.test.ts`
+Then `npm start`: add a template, click Materialize, confirm a transaction appears on the Transactions page for the month; click again → "Created 0, skipped 1". Stop the server.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add public/recurring.html public/js/recurring.js public/js/chrome.js test/recurringRender.test.ts test/chrome.test.ts
+git commit -m "feat(recurring): templates page with one-click materialize"
+```
+
+---
+
+### Task 5: Savings-over-time BI series (API)
+
+**Files:**
+- Modify: `src/application/use-cases/bi.ts` (`savingsTrend`)
+- Modify: `src/infra/composition.ts:83` (add `settings` dep to bi)
+- Modify: `src/adapters/http/controllers/bi.ts` (route)
+- Test: `test/bi.test.ts` (append)
+
+**Interfaces:**
+- Consumes: `ReportRepository.spendAllMonth`, `SettingsRepository.get`, `monthRange`.
+- Produces: `BiUseCases.savingsTrend(from, to)` → `{ months, series: [{ name: 'Projected savings', spent_cents }, { name: 'Goal', spent_cents }] }`; `GET /api/bi/savings-trend?from=&to=`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/bi.test.ts`:
+
+```ts
+test('savingsTrend = income - fixed - spend, vs goal', async () => {
+  const ctx = makeTestDb();
+  const app = createApp(ctx.db);
+  await request(app).put('/api/settings').send({ monthly_income: 1000000, fixed_costs: 300000, savings_goal: 200000 }).expect(200);
+  await request(app).post('/api/transactions').send({ date: '2026-06-10', category_id: ctx.categoryId,
+    card_id: ctx.cardId, amount_cents: 100000, description: 'x' }).expect(201);
+  const res = await request(app).get('/api/bi/savings-trend?from=2026-06&to=2026-06').expect(200);
+  const projected = res.body.series.find(s => s.name === 'Projected savings');
+  const goal = res.body.series.find(s => s.name === 'Goal');
+  assert.equal(projected.spent_cents[0], 600000); // 1,000,000 - 300,000 - 100,000
+  assert.equal(goal.spent_cents[0], 200000);
+});
+```
+
+- [ ] **Step 2: Run; confirm fail**
+
+Run: `npx tsx --test test/bi.test.ts`
+Expected: FAIL — route 404.
+
+- [ ] **Step 3: Extend the BI use-case**
+
+In `src/application/use-cases/bi.ts`, add `SettingsRepository` to deps:
+
+```ts
+import type {
+  ReportRepository, LimitRepository, CategoryRepository, CardRepository, GroupRepository, SettingsRepository,
+} from '../../domain/ports';
+```
+```ts
+export interface BiUseCaseDeps {
+  reports: ReportRepository; limits: LimitRepository; categories: CategoryRepository;
+  cards: CardRepository; groups: GroupRepository; settings: SettingsRepository;
+}
+```
+
+Destructure `settings` and add the method:
+
+```ts
+    savingsTrend(from: string, to: string) {
+      const months = monthRange(from, to);
+      const num = (k: string) => { const v = settings.get(k); return v !== undefined ? Number(v) : 0; };
+      const income = num('monthly_income');
+      const fixed = num('fixed_costs');
+      const goal = num('savings_goal');
+      const projected = months.map(m => income - fixed - reports.spendAllMonth(m));
+      return {
+        months,
+        series: [
+          { name: 'Projected savings', spent_cents: projected },
+          { name: 'Goal', spent_cents: months.map(() => goal) },
+        ],
+      };
+    },
+```
+
+- [ ] **Step 4: Wire settings into bi composition**
+
+In `src/infra/composition.ts`:
+
+```ts
+    bi: makeBiUseCases({
+      reports: repositories.reports, limits: repositories.limits,
+      categories: repositories.categories, cards: repositories.cards,
+      groups: repositories.groups, settings: repositories.settings,
+    }),
+```
+
+- [ ] **Step 5: Add the route**
+
+In `src/adapters/http/controllers/bi.ts`, add with the other range routes:
+
+```ts
+  router.get('/savings-trend', (req, res) => {
+    const { from, to } = range(req);
+    res.json(uc.savingsTrend(from, to));
+  });
+```
+
+- [ ] **Step 6: Run; confirm pass + coverage**
+
+Run: `npm run coverage`
+Expected: PASS, ≥80%.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/application/use-cases/bi.ts src/infra/composition.ts src/adapters/http/controllers/bi.ts test/bi.test.ts
+git commit -m "feat(bi): savings-over-time series (projected vs goal)"
+```
+
+---
+
+### Task 6: Savings-history chart (frontend)
+
+**Files:**
+- Modify: `public/bi.html` (canvas + heading)
+- Modify: `public/js/bi.js`
+
+**Interfaces:**
+- Consumes: `GET /api/bi/savings-trend?from=&to=`, `lineChart`.
+
+- [ ] **Step 1: Add a canvas to `bi.html`**
+
+Add a chart card mirroring the existing ones:
+
+```html
+<section class="paper-card mt-6">
+  <h2 class="font-display text-xl mb-1">Savings over time</h2>
+  <p class="text-xs text-ink-mut mb-3">Projected savings (income − fixed − spend) vs goal, using current settings.</p>
+  <canvas id="savingsTrend"></canvas>
+</section>
+```
+
+- [ ] **Step 2: Fetch + render in `bi.js`**
+
+Add `savings-trend` to the `Promise.all` and draw it:
+
+```js
+    const [trends, byCard, byGroup, bva, forecast, savings] = await Promise.all([
+      api.get(`/api/bi/trends?${qs}`), api.get(`/api/bi/by-card?${qs}`), api.get(`/api/bi/by-group?${qs}`),
+      api.get(`/api/bi/budget-vs-actual?${qs}`), api.get(`/api/bi/installment-forecast?${qs}`),
+      api.get(`/api/bi/savings-trend?${qs}`),
+    ]);
+    ...
+    lineChart('savingsTrend', savings.months, savings.series, false);
+```
+
+- [ ] **Step 3: Manual smoke**
+
+Run: `npm start` → BI page shows the new chart with a projected line vs a flat goal line. Stop the server.
+
+- [ ] **Step 4: Full suite + commit**
+
+Run: `npm run coverage`
+```bash
+git add public/bi.html public/js/bi.js
+git commit -m "feat(bi): savings-over-time chart on the BI page"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** recurring templates (migration/repo Task 1, use-case+materialize Task 2, API Task 3, UI Task 4) — covers "one-click materialize each month's charges, flagging when an amount changed"; savings history (API Task 5, chart Task 6) — "income − fixed − actual spend per month, vs goal".
+- **Placeholder scan:** the two HTML shells (4.4, 6.1) reference `transactions.html`/existing chart cards for boilerplate, which exist; no TODOs.
+- **Type consistency:** `RecurringTemplate` defined once (Task 1) and used by repo/use-case/render. `RecurringInput` shape `{ description?, category_id, card_id, amount_cents, day_of_month }` matches schema (Task 3) and use-case (Task 2). `MaterializeResult` identical in use-case and tests. `chargeDate(month, day)` consistent. BI series use the `{ name, spent_cents }` shape that `datasetsFor`/`lineChart` require, so the savings chart reuses the existing renderer unchanged.
+- **Migration safety:** `004_recurring.sql` runs in tests (helper skips only `002_seed.sql`); `ALTER TABLE ADD COLUMN` is additive and compatible with existing rows.

--- a/docs/superpowers/plans/2026-06-27-phase-4-polish-and-bigger-bets.md
+++ b/docs/superpowers/plans/2026-06-27-phase-4-polish-and-bigger-bets.md
@@ -1,0 +1,695 @@
+# Phase 4 — Polish & Bigger Bets Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace raw browser `prompt()`/`confirm()` in Settings with inline editing + color swatches; add CSV export and an in-app SQLite backup download; and add per-card closing/due days with a "projected bill" statement view — the most on-theme, credit-card-specific feature.
+
+**Architecture:** Three slices. (1) Settings UX is pure frontend over existing endpoints, with small testable render helpers in `budget.js`. (2) CSV export adds a use-case method + route; backup adds a tiny db-backed controller. (3) Per-card statement adds migration `005` (`cards.closing_day`/`due_day`), a `ReportRepository.spendByCardDateRange`, a statement use-case method, and routes on the existing cards controller.
+
+**Tech Stack:** TypeScript hexagonal, Express 5, better-sqlite3, zod, `node:test` + supertest, vanilla ESM.
+
+## Global Constraints
+
+(Same as Phases 0–3; repeated so this plan stands alone.)
+
+- Node 22; money in integer **cents**; months `YYYY-MM`, dates `YYYY-MM-DD`.
+- Hexagonal layering; ports in `src/domain/ports/index.ts`; entities in `src/domain/entities/index.ts`; errors via `AppError`.
+- Tests CommonJS `require('node:test')`; `makeTestDb()` for DB, `supertest` + `createApp(ctx.db)` for API; coverage ≥80% (`npm run coverage`).
+- HTTP validation via zod + `parse()`; existence rules in use-cases.
+- Frontend render functions pure + unit-tested; DOM bootstrap follows existing pages.
+- Commit after each task.
+
+## Dependency & Design Decisions (review before executing)
+
+1. **This phase assumes Phases 0–3 are merged.** Per-card statement reuses `chargeDate(month, day)` / `daysInMonth(month)` from `src/domain/services/dates.ts` (added in Phase 3, Task 2). If running Phase 4 standalone, add those two helpers first.
+2. **Statement cycle:** a card with `closing_day = c` produces, for target month `M`, a statement covering transactions dated in the window `( chargeDate(M-1, c) , chargeDate(M, c) ]` (exclusive→inclusive). If `closing_day` is null, fall back to the calendar month. `due_day` (if set) is rendered as `chargeDate(M, due_day)` in the same month.
+3. **Backup is a download; full restore stays a documented file-copy.** `GET /api/backup` streams `db.serialize()`. A safe in-process *restore* would require a server restart anyway (the DB file is locked while open), so restore is a stop-app-and-swap-the-file operation documented in the README — not a risky live endpoint. (A swap-on-restart endpoint is a possible future enhancement.)
+4. **CSV export reflects the current filters** (month/category/card/search) and has no pagination.
+
+---
+
+### Task 1: Color swatches replace the recolor `prompt()`
+
+**Files:**
+- Modify: `public/js/budget.js` (export `GROUP_COLORS`, `colorSwatches`; use it in `renderGroupedLimitRows`)
+- Modify: `public/js/settings.js` (handle `data-group-color`; delete `recolorGroup`/`COLORS`)
+- Test: `test/budget.test.ts` (append)
+
+**Interfaces:**
+- Produces: `colorSwatches(groupId, current): string`; clicking a swatch issues `PUT /api/groups/:id` with the new color.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/budget.test.ts`:
+
+```ts
+test('colorSwatches renders a button per palette color and marks the current', async () => {
+  const { colorSwatches, GROUP_COLORS } = await import('../public/js/budget.js');
+  const html = colorSwatches(3, 'gold');
+  for (const c of GROUP_COLORS) assert.match(html, new RegExp(`data-color="${c}"`));
+  assert.match(html, /data-group-color="3"/);
+  assert.match(html, /data-color="gold"[^>]*ring/); // current is highlighted
+});
+```
+
+- [ ] **Step 2: Run; confirm fail**
+
+Run: `npx tsx --test test/budget.test.ts`
+Expected: FAIL — `colorSwatches` not exported.
+
+- [ ] **Step 3: Implement the helper in `budget.js`**
+
+```js
+export const GROUP_COLORS = ['sage', 'gold', 'slate', 'neutral'];
+
+export function colorSwatches(groupId, current) {
+  return GROUP_COLORS.map(c =>
+    `<button data-group-color="${groupId}" data-color="${c}" title="${c}"
+       class="tag tag-${c} mr-1 ${c === current ? 'ring-2 ring-ink' : ''}">${c}</button>`).join('');
+}
+```
+
+In `renderGroupedLimitRows`, replace the single `data-group-recolor` button with the swatches:
+
+```js
+        <td class="py-2 text-right">
+          <button data-group-rename="${g.id}" class="text-sage text-sm mr-2">Rename</button>
+          ${colorSwatches(g.id, g.color)}
+          <button data-group-del="${g.id}" class="text-clay text-sm">Remove</button>
+        </td>
+```
+
+- [ ] **Step 4: Wire the click + remove the prompt in `settings.js`**
+
+In `onLimitsClick`, replace the `groupRecolor` branch with:
+
+```js
+    if (d.groupColor) {
+      const g = state.groups.find(x => x.id === Number(d.groupColor));
+      await api.put(`/api/groups/${d.groupColor}`, { ...g, color: d.color });
+      await loadLimits();
+      return;
+    }
+```
+
+Delete the `recolorGroup` function and the now-unused `COLORS` constant.
+
+- [ ] **Step 5: Run test + manual smoke + commit**
+
+Run: `npx tsx --test test/budget.test.ts`
+Then `npm start`: click a swatch on a group; confirm the chip recolors with no prompt. Stop the server.
+```bash
+git add public/js/budget.js public/js/settings.js test/budget.test.ts
+git commit -m "feat(settings): color swatches replace the recolor prompt"
+```
+
+---
+
+### Task 2: Inline rename + add replace the remaining `prompt()`s
+
+**Files:**
+- Modify: `public/js/budget.js` (`nameEditor` helper)
+- Modify: `public/js/settings.js` (inline rename for category/group; inline add)
+- Test: `test/budget.test.ts` (append)
+
+**Interfaces:**
+- Produces: `nameEditor(kind, id, value): string` — an inline `<input>` + Save/Cancel markup (`kind` is `'cat'` or `'group'`). Rename/add no longer call `prompt()`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+test('nameEditor renders an input prefilled with the current value', async () => {
+  const { nameEditor } = await import('../public/js/budget.js');
+  const html = nameEditor('cat', 5, 'Mercado');
+  assert.match(html, /data-save="cat:5"/);
+  assert.match(html, /data-cancel="cat:5"/);
+  assert.match(html, /value="Mercado"/);
+});
+
+test('nameEditor escapes the value', async () => {
+  const { nameEditor } = await import('../public/js/budget.js');
+  assert.doesNotMatch(nameEditor('group', 1, '"<x>'), /<x>/);
+});
+```
+
+- [ ] **Step 2: Run; confirm fail**
+
+Run: `npx tsx --test test/budget.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement `nameEditor` in `budget.js`**
+
+```js
+export function nameEditor(kind, id, value) {
+  return `<span class="inline-flex items-center gap-1">
+    <input data-edit-input="${kind}:${id}" value="${esc(value)}"
+      class="rounded border border-line px-2 py-0.5 text-sm" />
+    <button data-save="${kind}:${id}" class="text-sage text-sm">Save</button>
+    <button data-cancel="${kind}:${id}" class="text-ink-mut text-sm">Cancel</button>
+  </span>`;
+}
+```
+
+- [ ] **Step 4: Wire inline rename in `settings.js`**
+
+Replace `renameCategory`/`renameGroup` (which used `prompt`) with handlers that swap the cell to `nameEditor(...)` on "Rename", and persist on "Save". Sketch (adapt selectors to the table cell that holds the name):
+
+```js
+import { ceilingText, renderLimitRows, renderGroupedLimitRows, colorSwatches, nameEditor,
+  allocationStatus, allocationText, allocationPillClass } from './budget.js';
+
+function beginRename(kind, id) {
+  const cell = $('limits').querySelector(`[data-name-cell="${kind}:${id}"]`);
+  if (!cell) return;
+  const cur = kind === 'cat'
+    ? state.cats.find(c => c.id === id).name
+    : state.groups.find(g => g.id === id).name;
+  cell.innerHTML = nameEditor(kind, id, cur);
+  cell.querySelector('input').focus();
+}
+
+async function saveRename(kind, id) {
+  const val = $('limits').querySelector(`[data-edit-input="${kind}:${id}"]`).value.trim();
+  if (!val) return loadLimits();
+  if (kind === 'cat') {
+    const c = state.cats.find(x => x.id === id);
+    await api.put(`/api/categories/${id}`, { ...c, name: val });
+  } else {
+    const g = state.groups.find(x => x.id === id);
+    await api.put(`/api/groups/${id}`, { ...g, name: val });
+  }
+  await loadLimits();
+}
+```
+
+Add `data-name-cell="cat:${c.id}"` / `data-name-cell="group:${g.id}"` attributes to the name `<td>`s in `renderGroupedLimitRows`, and extend `onLimitsClick` to route `data-cat-rename`/`data-group-rename` → `beginRename`, `data-save` → `saveRename`, `data-cancel` → `loadLimits`.
+
+- [ ] **Step 5: Inline add (replace `addCategory`/`addGroup` prompts)**
+
+Replace the `prompt('New category name')` / `prompt('New group name')` flow with an inline input revealed under the "+ Add category"/"+ Add group" buttons (reuse `nameEditor('cat', 'new')` / `nameEditor('group', 'new')`), POSTing on Save. Keep the existing `data-add-cat`/`data-add-group` triggers; on click, render the editor in place and wire its Save to `api.post`.
+
+- [ ] **Step 6: Run tests + manual smoke + commit**
+
+Run: `npx tsx --test test/budget.test.ts`
+Then `npm start`: rename a category and a group inline; add a category inline — no browser prompts appear. Stop the server.
+```bash
+git add public/js/budget.js public/js/settings.js test/budget.test.ts
+git commit -m "feat(settings): inline rename/add replace browser prompts"
+```
+
+---
+
+### Task 3: CSV export of transactions
+
+**Files:**
+- Modify: `src/application/use-cases/transactions.ts` (`exportCsv`)
+- Modify: `src/adapters/http/controllers/transactions.ts` (`GET /export.csv`)
+- Test: `test/transactions.test.ts` (append)
+
+**Interfaces:**
+- Consumes: `TransactionRepository.list` (unpaginated), `CategoryRepository.listAll`, `CardRepository.listAll`.
+- Produces: `TransactionUseCases.exportCsv(filter: { month?; categoryId?; cardId?; q? }): string`; `GET /api/transactions/export.csv` → `text/csv`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+test('GET /api/transactions/export.csv returns a CSV with a header and rows', async () => {
+  const ctx = makeTestDb();
+  const app = createApp(ctx.db);
+  await request(app).post('/api/transactions').send({ date: '2026-06-01', category_id: ctx.categoryId,
+    card_id: ctx.cardId, amount_cents: 1234, description: 'Coffee, hot' }).expect(201);
+  const res = await request(app).get('/api/transactions/export.csv').expect(200);
+  assert.match(res.headers['content-type'], /text\/csv/);
+  assert.match(res.text, /date,category,card,amount_cents,description/);
+  assert.match(res.text, /Supermercado/);
+  assert.match(res.text, /"Coffee, hot"/); // comma-containing field is quoted
+});
+```
+
+- [ ] **Step 2: Run; confirm fail**
+
+Run: `npx tsx --test test/transactions.test.ts`
+Expected: FAIL — route 404.
+
+- [ ] **Step 3: Add `exportCsv` to the use-case**
+
+In `src/application/use-cases/transactions.ts`, add to the returned object:
+
+```ts
+    exportCsv(filter: { month?: string; categoryId?: number; cardId?: number; q?: string }): string {
+      const items = transactions.list({ ...filter, limit: null, offset: 0 });
+      const catName = new Map(categories.listAll().map(c => [c.id, c.name]));
+      const cardName = new Map(cards.listAll().map(c => [c.id, c.name]));
+      const cell = (v: unknown) => {
+        const s = String(v ?? '');
+        return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+      };
+      const header = ['date', 'category', 'card', 'amount_cents', 'description', 'installment_no', 'installment_total'];
+      const rows = items.map(t => [
+        t.date, catName.get(t.category_id) ?? '', cardName.get(t.card_id) ?? '',
+        t.amount_cents, t.description, t.installment_no ?? '', t.installment_total ?? '',
+      ].map(cell).join(','));
+      return [header.join(','), ...rows].join('\n');
+    },
+```
+
+- [ ] **Step 4: Add the route**
+
+In `src/adapters/http/controllers/transactions.ts`, add **before** `router.put('/:id', ...)`:
+
+```ts
+  router.get('/export.csv', (req, res) => {
+    const filter: Record<string, unknown> = {};
+    if (req.query.month !== undefined) filter.month = String(req.query.month);
+    if (req.query.category_id !== undefined) filter.categoryId = Number(req.query.category_id);
+    if (req.query.card_id !== undefined) filter.cardId = Number(req.query.card_id);
+    if (req.query.q !== undefined) filter.q = String(req.query.q);
+    res.attachment('transactions.csv').type('text/csv').send(uc.exportCsv(filter));
+  });
+```
+
+- [ ] **Step 5: Run; confirm pass + commit**
+
+Run: `npx tsx --test test/transactions.test.ts`
+```bash
+git add src/application/use-cases/transactions.ts src/adapters/http/controllers/transactions.ts test/transactions.test.ts
+git commit -m "feat(transactions): CSV export endpoint"
+```
+
+---
+
+### Task 4: SQLite backup download (+ README restore note)
+
+**Files:**
+- Create: `src/adapters/http/controllers/backup.ts`
+- Modify: `src/infra/composition.ts` (`backup` controller built from `db`)
+- Modify: `src/app.ts` (mount `/api/backup`)
+- Modify: `README.md` (restore = stop app, replace `data/gastando.db`)
+- Modify: `public/settings.html` + `public/js/settings.js` (a "Download backup" link) and `public/transactions.html` + `public/js/transactions.js` (an "Export CSV" link)
+- Test: `test/backup.test.ts` (new)
+
+**Interfaces:**
+- Produces: `GET /api/backup` → `application/octet-stream` attachment of `db.serialize()`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/backup.test.ts`:
+
+```ts
+const { test } = require('node:test');
+const assert = require('node:assert');
+const request = require('supertest');
+const { makeTestDb } = require('./helpers');
+const { createApp } = require('../src/app');
+
+test('GET /api/backup streams a SQLite file', async () => {
+  const ctx = makeTestDb();
+  const app = createApp(ctx.db);
+  const res = await request(app).get('/api/backup').expect(200);
+  assert.match(res.headers['content-disposition'], /attachment/);
+  // SQLite files start with the "SQLite format 3\0" magic header.
+  assert.match(res.body.slice(0, 15).toString('utf8'), /SQLite format 3/);
+});
+```
+
+- [ ] **Step 2: Run; confirm fail**
+
+Run: `npx tsx --test test/backup.test.ts`
+Expected: FAIL — route 404.
+
+- [ ] **Step 3: Write the controller**
+
+Create `src/adapters/http/controllers/backup.ts`:
+
+```ts
+import express from 'express';
+import type { Db } from '../../../infra/db';
+
+export function makeBackupController(db: Db): express.Router {
+  const router = express.Router();
+  router.get('/', (_req, res) => {
+    const buf = db.serialize();
+    const stamp = new Date().toISOString().slice(0, 10);
+    res.attachment(`gastando-backup-${stamp}.db`).type('application/octet-stream').send(buf);
+  });
+  return router;
+}
+```
+
+- [ ] **Step 4: Wire it (composition + app)**
+
+In `src/infra/composition.ts`: import `makeBackupController`; add `backup: express.Router;` to `Container.controllers`; and in `controllers`, add `backup: makeBackupController(db)`.
+
+In `src/app.ts`, add: `app.use('/api/backup', controllers.backup);`
+
+- [ ] **Step 5: Run; confirm pass**
+
+Run: `npx tsx --test test/backup.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Add the UI links**
+
+In `transactions.html`, add an `<a id="exportCsv" class="btn-ghost text-sm">Export CSV</a>`; in `transactions.js` bootstrap set its href from the current filters on each `loadList` (or point it at `/api/transactions/export.csv?month=${$('month').value}`).
+In `settings.html`, add `<a href="/api/backup" class="btn-ghost text-sm">Download backup</a>`.
+
+- [ ] **Step 7: README restore note**
+
+In `README.md`, under data/backup, document: "To restore, stop the app and replace `data/gastando.db` with a downloaded backup, then start again." (Replaces the bare "copy the file by hand".)
+
+- [ ] **Step 8: Full suite + commit**
+
+Run: `npm run coverage`
+```bash
+git add src/adapters/http/controllers/backup.ts src/infra/composition.ts src/app.ts README.md public/settings.html public/transactions.html public/js/transactions.js test/backup.test.ts
+git commit -m "feat: SQLite backup download + CSV export links; document restore"
+```
+
+---
+
+### Task 5: Per-card closing/due day (migration + persistence)
+
+**Files:**
+- Create: `migrations/005_card_statement.sql`
+- Modify: `src/domain/entities/index.ts` (`Card.closing_day`, `Card.due_day`)
+- Modify: `src/domain/ports/index.ts` (`CardRepository.setStatementConfig`)
+- Modify: `src/infra/repositories/cards.ts`
+- Test: `test/crud.test.ts` (append) or `test/cardStatement.test.ts` (new)
+
+**Interfaces:**
+- Produces: `Card` carries nullable `closing_day` / `due_day`; `CardRepository.setStatementConfig(id, closingDay: number | null, dueDay: number | null): number`.
+
+- [ ] **Step 1: Write the migration**
+
+Create `migrations/005_card_statement.sql`:
+
+```sql
+ALTER TABLE cards ADD COLUMN closing_day INTEGER;
+ALTER TABLE cards ADD COLUMN due_day INTEGER;
+```
+
+- [ ] **Step 2: Write the failing repo test**
+
+Create `test/cardStatement.test.ts`:
+
+```ts
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { makeTestDb } = require('./helpers');
+const { makeCardRepository } = require('../src/infra/repositories/cards');
+
+test('setStatementConfig persists closing/due day', () => {
+  const ctx = makeTestDb();
+  const repo = makeCardRepository(ctx.db);
+  assert.equal(repo.setStatementConfig(ctx.cardId, 20, 27), 1);
+  const card = repo.findById(ctx.cardId);
+  assert.equal(card.closing_day, 20);
+  assert.equal(card.due_day, 27);
+});
+```
+
+- [ ] **Step 3: Add entity fields + port method**
+
+Entity: `export interface Card { id: number; name: string; active: number; closing_day: number | null; due_day: number | null; }`
+Port (`CardRepository`): `setStatementConfig(id: number, closingDay: number | null, dueDay: number | null): number;`
+
+- [ ] **Step 4: Implement in the repository**
+
+In `src/infra/repositories/cards.ts`, add to the returned object (the existing `SELECT *` queries already surface the new columns):
+
+```ts
+    setStatementConfig(id, closingDay, dueDay): number {
+      return db.prepare('UPDATE cards SET closing_day=?, due_day=? WHERE id=?')
+        .run(closingDay, dueDay, id).changes;
+    },
+```
+
+- [ ] **Step 5: Run; confirm pass + commit**
+
+Run: `npx tsx --test test/cardStatement.test.ts`
+```bash
+git add migrations/005_card_statement.sql src/domain/entities/index.ts src/domain/ports/index.ts src/infra/repositories/cards.ts test/cardStatement.test.ts
+git commit -m "feat(cards): closing/due day persistence"
+```
+
+---
+
+### Task 6: Per-card statement use-case + endpoints
+
+**Files:**
+- Modify: `src/domain/ports/index.ts` (`ReportRepository.spendByCardDateRange`)
+- Modify: `src/infra/repositories/reports.ts`
+- Modify: `src/application/use-cases/cards.ts` (`statement`, `setConfig`; add `reports` dep)
+- Modify: `src/infra/composition.ts:76` (pass `reports` to cards use-case)
+- Create: `src/adapters/http/schemas/cards.ts`
+- Modify: `src/adapters/http/controllers/cards.ts` (routes)
+- Test: `test/cardStatement.test.ts` (append API cases)
+
+**Interfaces:**
+- Consumes: `chargeDate`, `addMonths` from `dates`; `ReportRepository.spendByCardDateRange(cardId, startExclusive, endInclusive): number`.
+- Produces: `CardUseCases.statement(id, month)` → `{ card_id, month, closing_date, due_date, amount_cents }`; `setConfig(id, { closing_day, due_day })` → `Card`; `GET /api/cards/:id/statement?month=`, `PUT /api/cards/:id/statement-config`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+const request = require('supertest');
+const { createApp } = require('../src/app');
+
+test('card statement sums the closing-day cycle', async () => {
+  const ctx = makeTestDb();
+  const app = createApp(ctx.db);
+  await request(app).put(`/api/cards/${ctx.cardId}/statement-config`).send({ closing_day: 20, due_day: 27 }).expect(200);
+  const add = date => request(app).post('/api/transactions')
+    .send({ date, category_id: ctx.categoryId, card_id: ctx.cardId, amount_cents: 10000, description: 'x' }).expect(201);
+  await add('2026-05-25'); // after May 20 close -> belongs to June statement
+  await add('2026-06-10'); // before June 20 close -> June statement
+  await add('2026-06-25'); // after June 20 close -> July statement, excluded
+  const res = await request(app).get(`/api/cards/${ctx.cardId}/statement?month=2026-06`).expect(200);
+  assert.equal(res.body.amount_cents, 20000);
+  assert.equal(res.body.closing_date, '2026-06-20');
+  assert.equal(res.body.due_date, '2026-06-27');
+});
+```
+
+- [ ] **Step 2: Run; confirm fail**
+
+Run: `npx tsx --test test/cardStatement.test.ts`
+Expected: FAIL — config route 404.
+
+- [ ] **Step 3: Add the report method**
+
+Port (`ReportRepository`): `spendByCardDateRange(cardId: number, startExclusive: string, endInclusive: string): number;`
+Repo (`src/infra/repositories/reports.ts`):
+
+```ts
+    spendByCardDateRange(cardId: number, startExclusive: string, endInclusive: string): number {
+      return (db.prepare(
+        `SELECT COALESCE(SUM(amount_cents),0) AS s FROM transactions
+         WHERE card_id=? AND date > ? AND date <= ?`,
+      ).get(cardId, startExclusive, endInclusive) as { s: number }).s;
+    },
+```
+
+- [ ] **Step 4: Extend the cards use-case**
+
+```ts
+import type { Card } from '../../domain/entities';
+import type { CardRepository, ReportRepository } from '../../domain/ports';
+import { AppError } from '../../domain/errors';
+import { addMonths, chargeDate } from '../../domain/services/dates';
+
+export interface CardUseCaseDeps { cards: CardRepository; reports: ReportRepository; }
+```
+
+Add to the returned object:
+
+```ts
+    setConfig(id: number, body: { closing_day: number | null; due_day: number | null }): Card {
+      if (cards.setStatementConfig(id, body.closing_day, body.due_day) === 0) {
+        throw new AppError(404, 'card not found');
+      }
+      return cards.findById(id) as Card;
+    },
+
+    statement(id: number, month: string) {
+      const card = cards.findById(id);
+      if (!card) throw new AppError(404, 'card not found');
+      if (card.closing_day == null) {
+        // No cycle configured: fall back to the calendar month window.
+        const start = chargeDate(addMonths(month, -1), 31); // last day of prev month, exclusive
+        const end = chargeDate(month, 31);                  // last day of this month, inclusive
+        return { card_id: id, month, closing_date: null, due_date: null,
+          amount_cents: reports.spendByCardDateRange(id, start, end) };
+      }
+      const closing_date = chargeDate(month, card.closing_day);
+      const start = chargeDate(addMonths(month, -1), card.closing_day);
+      const due_date = card.due_day != null ? chargeDate(month, card.due_day) : null;
+      return { card_id: id, month, closing_date, due_date,
+        amount_cents: reports.spendByCardDateRange(id, start, closing_date) };
+    },
+```
+
+- [ ] **Step 5: Wire `reports` into cards composition**
+
+In `src/infra/composition.ts`:
+
+```ts
+    cards: makeCardUseCases({ cards: repositories.cards, reports: repositories.reports }),
+```
+
+- [ ] **Step 6: Schema + routes**
+
+Create `src/adapters/http/schemas/cards.ts`:
+
+```ts
+import { z } from 'zod';
+
+const dayOrNull = z.custom<number | null>(
+  v => v === null || v === undefined || (typeof v === 'number' && Number.isInteger(v) && v >= 1 && v <= 31),
+  { message: 'day must be an integer 1..31 or null' });
+
+export const statementConfigSchema = z.object({ closing_day: dayOrNull, due_day: dayOrNull });
+```
+
+In `src/adapters/http/controllers/cards.ts`, import `parse`-friendly schema and add **before** `router.put('/:id', ...)`:
+
+```ts
+import { statementConfigSchema } from '../schemas/cards';
+import { MONTH_RE } from '../schemas/common';
+```
+```ts
+  router.get('/:id/statement', (req, res) => {
+    const q = req.query.month;
+    const month = (typeof q === 'string' && MONTH_RE.test(q)) ? q : new Date().toISOString().slice(0, 7);
+    res.json(uc.statement(Number(req.params.id), month));
+  });
+
+  router.put('/:id/statement-config', (req, res) => {
+    const body = parse(statementConfigSchema, req.body);
+    res.json(uc.setConfig(Number(req.params.id), { closing_day: body.closing_day ?? null, due_day: body.due_day ?? null }));
+  });
+```
+
+- [ ] **Step 7: Run; confirm pass + coverage**
+
+Run: `npm run coverage`
+Expected: PASS, ≥80%.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/domain/ports/index.ts src/infra/repositories/reports.ts src/application/use-cases/cards.ts src/infra/composition.ts src/adapters/http/schemas/cards.ts src/adapters/http/controllers/cards.ts test/cardStatement.test.ts
+git commit -m "feat(cards): per-card statement (closing-day cycle) + config endpoint"
+```
+
+---
+
+### Task 7: Per-card statement UI (Settings)
+
+**Files:**
+- Modify: `public/js/settings.js` (`renderCards` pure helper + wiring)
+- Test: `test/settingsRender.test.ts` (append)
+
+**Interfaces:**
+- Consumes: `/api/cards`, `GET /api/cards/:id/statement?month=`, `PUT /api/cards/:id/statement-config`.
+- Produces: pure `renderCards(cards, statementByCard, month): string` showing name, closing/due-day inputs, and the projected bill.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/settingsRender.test.ts`:
+
+```ts
+test('renderCards shows the projected bill and config inputs', async () => {
+  const { renderCards } = await import('../public/js/settings.js');
+  const cards = [{ id: 2, name: 'Nubank', active: 1, closing_day: 20, due_day: 27 }];
+  const stmt = new Map([[2, { amount_cents: 35000, closing_date: '2026-06-20', due_date: '2026-06-27' }]]);
+  const html = renderCards(cards, stmt, '2026-06');
+  assert.match(html, /Nubank/);
+  assert.match(html, /R\$ 350,00/);          // projected bill
+  assert.match(html, /data-closing="2"/);
+  assert.match(html, /value="20"/);
+});
+```
+
+(If `settings.js`'s bootstrap currently throws when imported headlessly, ensure `renderCards` is exported at module top-level — like `renderHero` in `dashboard.js` — so the import works under `node:test`.)
+
+- [ ] **Step 2: Run; confirm fail**
+
+Run: `npx tsx --test test/settingsRender.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement `renderCards` (top-level export) in `settings.js`**
+
+```js
+export function renderCards(cards, stmtByCard, month) {
+  return cards.filter(c => c.active).map(c => {
+    const s = stmtByCard.get(c.id);
+    return `
+      <div class="paper-card" data-card="${c.id}">
+        <div class="flex items-center justify-between">
+          <span class="font-semibold">${esc(c.name)}</span>
+          <button data-del="${c.id}" class="text-clay text-sm">Remove</button>
+        </div>
+        <div class="mt-2 flex items-center gap-3 text-sm">
+          <label>Closing <input type="number" min="1" max="31" data-closing="${c.id}"
+            value="${c.closing_day ?? ''}" class="w-16 rounded border border-line px-1" /></label>
+          <label>Due <input type="number" min="1" max="31" data-due="${c.id}"
+            value="${c.due_day ?? ''}" class="w-16 rounded border border-line px-1" /></label>
+          <span class="ml-auto font-mono">${s ? `Bill ${formatBRL(s.amount_cents)}` : ''}</span>
+        </div>
+      </div>`;
+  }).join('');
+}
+```
+
+(Add `esc`, `formatBRL` to the `./format.js` import.)
+
+- [ ] **Step 4: Wire `loadCards` to use it**
+
+Replace the body of `loadCards` to fetch cards + each card's statement for `$('month').value`, render with `renderCards`, then wire: `data-del` → delete; `change` on `data-closing`/`data-due` → `PUT /api/cards/:id/statement-config` with both current values, then reload.
+
+```js
+async function loadCards() {
+  try {
+    const cards = await api.get('/api/cards');
+    const active = cards.filter(c => c.active);
+    const stmts = await Promise.all(active.map(c =>
+      api.get(`/api/cards/${c.id}/statement?month=${$('month').value}`).then(s => [c.id, s])));
+    $('cards').innerHTML = renderCards(cards, new Map(stmts), $('month').value);
+    $('cards').querySelectorAll('button[data-del]').forEach(b =>
+      b.addEventListener('click', async () => { try { await api.del(`/api/cards/${b.dataset.del}`); loadCards(); } catch (e) { showError(e.message); } }));
+    const saveCfg = async id => {
+      const closing = $('cards').querySelector(`input[data-closing="${id}"]`).value;
+      const due = $('cards').querySelector(`input[data-due="${id}"]`).value;
+      try {
+        await api.put(`/api/cards/${id}/statement-config`,
+          { closing_day: closing ? Number(closing) : null, due_day: due ? Number(due) : null });
+        loadCards();
+      } catch (e) { showError(e.message); }
+    };
+    $('cards').querySelectorAll('input[data-closing],input[data-due]').forEach(inp =>
+      inp.addEventListener('change', () => saveCfg(Number(inp.dataset.closing ?? inp.dataset.due))));
+  } catch (e) { showError(e.message); }
+}
+```
+
+- [ ] **Step 5: Run render test + manual smoke**
+
+Run: `npx tsx --test test/settingsRender.test.ts`
+Then `npm start`: set a card's closing day, add transactions around it, confirm the projected bill updates. Stop the server.
+
+- [ ] **Step 6: Full suite + commit**
+
+Run: `npm run coverage`
+```bash
+git add public/js/settings.js test/settingsRender.test.ts
+git commit -m "feat(cards): per-card projected bill + closing/due config in Settings"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** replace prompt/confirm (swatches Task 1; inline rename/add Task 2 — the `confirm()` deletes already became inline/guarded in earlier phases, and Settings deletes here go through buttons, not `confirm`); CSV export (Task 3) + backup download + restore documentation (Task 4); per-card statement (closing/due persistence Task 5, statement logic + endpoints Task 6, UI Task 7).
+- **Placeholder scan:** Tasks 2 and 7 contain UI-wiring sketches rather than line-exact diffs because that wiring is DOM-interaction the codebase verifies by manual smoke, not unit tests; each still ships a *tested* pure helper (`nameEditor`, `renderCards`) and concrete code. No "TODO"/"handle later" text.
+- **Type consistency:** `Card` gains `closing_day`/`due_day` (Task 5) consumed by use-case (Task 6) and UI (Task 7). `setStatementConfig(id, closingDay, dueDay)` identical across port/repo/use-case. `spendByCardDateRange(cardId, startExclusive, endInclusive)` consistent port↔repo↔use-case. Statement window matches Design Decision 2. `statementConfigSchema` field names `closing_day`/`due_day` match the use-case and UI.
+- **Dependency check:** per-card statement reuses `chargeDate`/`addMonths` (dates.ts) — `addMonths` exists today; `chargeDate` is added in Phase 3 (Design Decision 1 flags this for standalone runs).

--- a/public/js/chrome.js
+++ b/public/js/chrome.js
@@ -1,6 +1,7 @@
 export const NAV_ITEMS = [
   { href: '/', label: 'Dashboard', route: '/' },
   { href: '/transactions.html', label: 'Transactions', route: '/transactions.html' },
+  { href: '/parcelas.html', label: 'Parcelas', route: '/parcelas.html' },
   { href: '/settings.html', label: 'Settings', route: '/settings.html' },
   { href: '/bi.html', label: 'BI', route: '/bi.html' },
   { href: '/simulate.html', label: 'Simulate', route: '/simulate.html' },

--- a/public/js/parcelas.js
+++ b/public/js/parcelas.js
@@ -1,0 +1,131 @@
+import { api, showError } from './api.js';
+import { mountChrome } from './chrome.js';
+import { currentMonth, esc, formatBRL } from './format.js';
+
+const $ = (id) => document.getElementById(id);
+
+export function renderGroups(rows) {
+  if (!rows.length) {
+    return `<p class="paper-card text-ink-mut">No installment purchases yet.</p>`;
+  }
+  return rows
+    .map(
+      (r) => `
+    <div class="paper-card" data-row="${r.id}">
+      <div class="flex items-start justify-between gap-4">
+        <div>
+          <div class="font-semibold">${esc(r.description) || 'Installment'}</div>
+          <div class="text-xs text-ink-mut mt-0.5">${esc(r.category_name)} · ${esc(r.card_name)}</div>
+        </div>
+        <span class="tag tag-gold">${r.paid_count}/${r.total_count}</span>
+      </div>
+      <div class="mt-3 grid grid-cols-3 gap-3 text-sm">
+        <div><div class="text-ink-mut text-xs">Monthly</div><div class="font-mono">${formatBRL(r.monthly_cents)}</div></div>
+        <div><div class="text-ink-mut text-xs">Remaining</div><div class="font-mono">${formatBRL(r.remaining_cents)}</div></div>
+        <div><div class="text-ink-mut text-xs">Next</div><div class="font-mono">${r.next_month || '—'}</div></div>
+      </div>
+      <div class="mt-3 text-right">
+        <button data-edit="${r.id}" class="text-sage text-sm mr-2">Edit</button>
+        ${r.remaining_count > 0 ? `<button data-payoff="${r.id}" class="text-sage text-sm mr-2">Pay off early</button>` : ''}
+        <button data-del="${r.id}" class="text-clay text-sm">Delete</button>
+      </div>
+    </div>`,
+    )
+    .join('');
+}
+
+async function load() {
+  try {
+    const rows = await api.get(`/api/installment-groups?month=${$('month').value}`);
+    $('list').innerHTML = renderGroups(rows);
+    wire(rows);
+  } catch (e) {
+    showError(e.message);
+  }
+}
+
+function wire(rows) {
+  $('list')
+    .querySelectorAll('button[data-del]')
+    .forEach((b) => {
+      b.addEventListener('click', async () => {
+        if (!confirm('Delete this installment group (all parcelas)?')) return;
+        try {
+          await api.del(`/api/installment-groups/${b.dataset.del}`);
+          load();
+        } catch (e) {
+          showError(e.message);
+        }
+      });
+    });
+  $('list')
+    .querySelectorAll('button[data-payoff]')
+    .forEach((b) => {
+      b.addEventListener('click', async () => {
+        if (!confirm('Pay off early? Remaining parcelas move into this month.')) return;
+        try {
+          await api.post(`/api/installment-groups/${b.dataset.payoff}/payoff`, {
+            month: $('month').value,
+          });
+          load();
+        } catch (e) {
+          showError(e.message);
+        }
+      });
+    });
+  $('list')
+    .querySelectorAll('button[data-edit]')
+    .forEach((b) => {
+      b.addEventListener('click', () =>
+        startEdit(rows.find((r) => r.id === Number(b.dataset.edit))),
+      );
+    });
+}
+
+function startEdit(r) {
+  if (!r) return;
+  $('editId').value = r.id;
+  $('e_description').value = r.description;
+  $('e_total').value = (r.total_cents / 100).toFixed(2);
+  $('e_count').value = r.total_count;
+  $('e_firstMonth').value = r.first_month;
+  $('editCard').style.display = 'block';
+  $('editCard').scrollIntoView({ block: 'center' });
+}
+
+if (typeof document !== 'undefined' && document.getElementById('list')) {
+  mountChrome('/parcelas.html');
+  $('month').value = currentMonth();
+  $('month').addEventListener('change', load);
+  $('editForm').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    try {
+      await api.put(`/api/installment-groups/${$('editId').value}`, {
+        category_id: Number($('e_category').value),
+        card_id: Number($('e_card').value),
+        description: $('e_description').value,
+        total_cents: Math.round(Number($('e_total').value) * 100),
+        count: Number($('e_count').value),
+        first_month: $('e_firstMonth').value,
+      });
+      $('editCard').style.display = 'none';
+      load();
+    } catch (err) {
+      showError(err.message);
+    }
+  });
+  // populate category/card selects in the edit form
+  Promise.all([api.get('/api/categories'), api.get('/api/cards')])
+    .then(([cats, cards]) => {
+      $('e_category').innerHTML = cats
+        .filter((c) => c.active)
+        .map((c) => `<option value="${c.id}">${esc(c.name)}</option>`)
+        .join('');
+      $('e_card').innerHTML = cards
+        .filter((c) => c.active)
+        .map((c) => `<option value="${c.id}">${esc(c.name)}</option>`)
+        .join('');
+    })
+    .catch((e) => showError(e.message));
+  load();
+}

--- a/public/parcelas.html
+++ b/public/parcelas.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Gastando — Parcelas</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@600;700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="/css/app.css" />
+</head>
+<body class="pb-24 md:pb-0">
+  <div id="nav"></div>
+  <main class="max-w-5xl mx-auto px-6 py-8">
+    <div class="flex items-center justify-between mb-6">
+      <h1 class="font-display text-3xl">Parcelas</h1>
+      <input type="month" id="month" class="rounded border border-line bg-card px-3 py-2" />
+    </div>
+    <div id="list" class="space-y-4"></div>
+
+    <div id="editCard" class="paper-card mt-8" style="display:none">
+      <h2 class="font-display text-xl mb-4">Edit installment</h2>
+      <form id="editForm" class="grid gap-3 md:grid-cols-2">
+        <input type="hidden" id="editId" />
+        <label class="block">Description <input id="e_description" class="w-full rounded border border-line px-2 py-1" /></label>
+        <label class="block">Category <select id="e_category" class="w-full rounded border border-line px-2 py-1"></select></label>
+        <label class="block">Card <select id="e_card" class="w-full rounded border border-line px-2 py-1"></select></label>
+        <label class="block">Total (R$) <input id="e_total" type="number" step="0.01" class="w-full rounded border border-line px-2 py-1" /></label>
+        <label class="block">Parcelas <input id="e_count" type="number" min="1" class="w-full rounded border border-line px-2 py-1" /></label>
+        <label class="block">First month <input id="e_firstMonth" type="month" class="w-full rounded border border-line px-2 py-1" /></label>
+        <div class="md:col-span-2 text-right"><button class="btn-primary">Save</button></div>
+      </form>
+    </div>
+  </main>
+  <script type="module" src="/js/parcelas.js"></script>
+</body>
+</html>

--- a/src/adapters/http/controllers/installmentGroups.ts
+++ b/src/adapters/http/controllers/installmentGroups.ts
@@ -18,7 +18,7 @@ export function makeInstallmentGroupsController(uc: InstallmentUseCases): expres
 
   router.put('/:id', (req, res) => {
     const body = parse(updateInstallmentSchema, req.body);
-    uc.update(Number(req.params.id), { ...body, description: req.body.description ?? '' });
+    uc.update(Number(req.params.id), { ...body, description: body.description ?? '' });
     res.status(204).end();
   });
 

--- a/src/adapters/http/controllers/installmentGroups.ts
+++ b/src/adapters/http/controllers/installmentGroups.ts
@@ -22,6 +22,14 @@ export function makeInstallmentGroupsController(uc: InstallmentUseCases): expres
     res.status(204).end();
   });
 
+  router.post('/:id/payoff', (req, res) => {
+    const m = req.body.month;
+    const month =
+      typeof m === 'string' && MONTH_RE.test(m) ? m : new Date().toISOString().slice(0, 7);
+    uc.payOff(Number(req.params.id), month);
+    res.status(204).end();
+  });
+
   router.delete('/:id', (req, res) => {
     uc.remove(Number(req.params.id));
     res.status(204).end();

--- a/src/adapters/http/controllers/installmentGroups.ts
+++ b/src/adapters/http/controllers/installmentGroups.ts
@@ -1,13 +1,31 @@
 import express from 'express';
 import type { makeInstallmentUseCases } from '../../../application/use-cases/installments';
+import { MONTH_RE } from '../schemas/common';
+import { updateInstallmentSchema } from '../schemas/installments';
+import { parse } from '../validate';
 
 type InstallmentUseCases = ReturnType<typeof makeInstallmentUseCases>;
 
 export function makeInstallmentGroupsController(uc: InstallmentUseCases): express.Router {
   const router = express.Router();
+
+  router.get('/', (req, res) => {
+    const q = req.query.month;
+    const month =
+      typeof q === 'string' && MONTH_RE.test(q) ? q : new Date().toISOString().slice(0, 7);
+    res.json(uc.list(month));
+  });
+
+  router.put('/:id', (req, res) => {
+    const body = parse(updateInstallmentSchema, req.body);
+    uc.update(Number(req.params.id), { ...body, description: req.body.description ?? '' });
+    res.status(204).end();
+  });
+
   router.delete('/:id', (req, res) => {
     uc.remove(Number(req.params.id));
     res.status(204).end();
   });
+
   return router;
 }

--- a/src/adapters/http/schemas/installments.ts
+++ b/src/adapters/http/schemas/installments.ts
@@ -4,6 +4,7 @@ import { zMonth, zPositiveInt } from './common';
 export const updateInstallmentSchema = z.object({
   category_id: zPositiveInt('category_id must be a positive integer'),
   card_id: zPositiveInt('card_id must be a positive integer'),
+  description: z.string().optional(),
   total_cents: zPositiveInt('total_cents must be a positive integer'),
   count: zPositiveInt('count must be a positive integer'),
   first_month: zMonth('first_month must be YYYY-MM'),

--- a/src/adapters/http/schemas/installments.ts
+++ b/src/adapters/http/schemas/installments.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+import { zMonth, zPositiveInt } from './common';
+
+export const updateInstallmentSchema = z.object({
+  category_id: zPositiveInt('category_id must be a positive integer'),
+  card_id: zPositiveInt('card_id must be a positive integer'),
+  total_cents: zPositiveInt('total_cents must be a positive integer'),
+  count: zPositiveInt('count must be a positive integer'),
+  first_month: zMonth('first_month must be YYYY-MM'),
+});

--- a/src/application/use-cases/installments.ts
+++ b/src/application/use-cases/installments.ts
@@ -37,5 +37,8 @@ export function makeInstallmentUseCases(deps: InstallmentUseCaseDeps) {
     remove(id: number): void {
       installments.remove(id);
     },
+    payOff(id: number, asOfMonth: string): void {
+      installments.payOffEarly(id, asOfMonth);
+    },
   };
 }

--- a/src/application/use-cases/installments.ts
+++ b/src/application/use-cases/installments.ts
@@ -1,8 +1,6 @@
-import type {
-  InstallmentRepository, CategoryRepository, CardRepository,
-} from '../../domain/ports';
 import type { InstallmentProgress } from '../../domain/entities';
 import { AppError } from '../../domain/errors';
+import type { CardRepository, CategoryRepository, InstallmentRepository } from '../../domain/ports';
 
 export interface InstallmentUseCaseDeps {
   installments: InstallmentRepository;
@@ -11,8 +9,12 @@ export interface InstallmentUseCaseDeps {
 }
 
 export interface UpdateInstallmentInput {
-  category_id: number; card_id: number; description?: string;
-  total_cents: number; count: number; first_month: string;
+  category_id: number;
+  card_id: number;
+  description?: string;
+  total_cents: number;
+  count: number;
+  first_month: string;
 }
 
 export function makeInstallmentUseCases(deps: InstallmentUseCaseDeps) {

--- a/src/application/use-cases/installments.ts
+++ b/src/application/use-cases/installments.ts
@@ -1,12 +1,36 @@
-import type { InstallmentRepository } from '../../domain/ports';
+import type {
+  InstallmentRepository, CategoryRepository, CardRepository,
+} from '../../domain/ports';
+import type { InstallmentProgress } from '../../domain/entities';
+import { AppError } from '../../domain/errors';
 
 export interface InstallmentUseCaseDeps {
   installments: InstallmentRepository;
+  categories: CategoryRepository;
+  cards: CardRepository;
+}
+
+export interface UpdateInstallmentInput {
+  category_id: number; card_id: number; description?: string;
+  total_cents: number; count: number; first_month: string;
 }
 
 export function makeInstallmentUseCases(deps: InstallmentUseCaseDeps) {
-  const { installments } = deps;
+  const { installments, categories, cards } = deps;
+
+  function assertRefs(categoryId: number, cardId: number): void {
+    if (!categories.findById(categoryId)) throw new AppError(400, 'category_id does not exist');
+    if (!cards.findById(cardId)) throw new AppError(400, 'card_id does not exist');
+  }
+
   return {
+    list(asOfMonth: string): InstallmentProgress[] {
+      return installments.listWithProgress(asOfMonth);
+    },
+    update(id: number, input: UpdateInstallmentInput): void {
+      assertRefs(input.category_id, input.card_id);
+      installments.update(id, input);
+    },
     // Throws AppError(404) from the repository if the group does not exist.
     remove(id: number): void {
       installments.remove(id);

--- a/src/domain/entities/index.ts
+++ b/src/domain/entities/index.ts
@@ -33,6 +33,14 @@ export interface InstallmentGroup {
   category_id: number;
   card_id: number;
 }
+export interface InstallmentProgress {
+  id: number; description: string; category_id: number; card_id: number;
+  category_name: string; card_name: string;
+  total_cents: number; total_count: number; first_month: string;
+  paid_count: number; remaining_count: number;
+  paid_cents: number; remaining_cents: number;
+  monthly_cents: number; next_month: string | null;
+}
 export interface Transaction {
   id: number;
   date: string;

--- a/src/domain/entities/index.ts
+++ b/src/domain/entities/index.ts
@@ -34,12 +34,21 @@ export interface InstallmentGroup {
   card_id: number;
 }
 export interface InstallmentProgress {
-  id: number; description: string; category_id: number; card_id: number;
-  category_name: string; card_name: string;
-  total_cents: number; total_count: number; first_month: string;
-  paid_count: number; remaining_count: number;
-  paid_cents: number; remaining_cents: number;
-  monthly_cents: number; next_month: string | null;
+  id: number;
+  description: string;
+  category_id: number;
+  card_id: number;
+  category_name: string;
+  card_name: string;
+  total_cents: number;
+  total_count: number;
+  first_month: string;
+  paid_count: number;
+  remaining_count: number;
+  paid_cents: number;
+  remaining_cents: number;
+  monthly_cents: number;
+  next_month: string | null;
 }
 export interface Transaction {
   id: number;

--- a/src/domain/ports/index.ts
+++ b/src/domain/ports/index.ts
@@ -88,6 +88,10 @@ export interface InstallmentRepository {
   }): number;
   remove(id: number): void; // throws AppError(404) if absent
   listWithProgress(asOfMonth: string): InstallmentProgress[];
+  update(id: number, p: {
+    category_id: number; card_id: number; description?: string;
+    total_cents: number; count: number; first_month: string;
+  }): void;                              // atomic re-expand; throws AppError(404) if absent
 }
 
 export interface SettingsRepository {

--- a/src/domain/ports/index.ts
+++ b/src/domain/ports/index.ts
@@ -99,6 +99,7 @@ export interface InstallmentRepository {
       first_month: string;
     },
   ): void; // atomic re-expand; throws AppError(404) if absent
+  payOffEarly(id: number, asOfMonth: string): void; // re-date remaining parcelas to asOf; 404/400
 }
 
 export interface SettingsRepository {

--- a/src/domain/ports/index.ts
+++ b/src/domain/ports/index.ts
@@ -1,4 +1,4 @@
-import type { Card, Category, Group, Transaction } from '../entities';
+import type { Card, Category, Group, InstallmentProgress, Transaction } from '../entities';
 
 export interface GroupRepository {
   listActive(): Group[];
@@ -87,6 +87,7 @@ export interface InstallmentRepository {
     first_month: string;
   }): number;
   remove(id: number): void; // throws AppError(404) if absent
+  listWithProgress(asOfMonth: string): InstallmentProgress[];
 }
 
 export interface SettingsRepository {

--- a/src/domain/ports/index.ts
+++ b/src/domain/ports/index.ts
@@ -88,10 +88,17 @@ export interface InstallmentRepository {
   }): number;
   remove(id: number): void; // throws AppError(404) if absent
   listWithProgress(asOfMonth: string): InstallmentProgress[];
-  update(id: number, p: {
-    category_id: number; card_id: number; description?: string;
-    total_cents: number; count: number; first_month: string;
-  }): void;                              // atomic re-expand; throws AppError(404) if absent
+  update(
+    id: number,
+    p: {
+      category_id: number;
+      card_id: number;
+      description?: string;
+      total_cents: number;
+      count: number;
+      first_month: string;
+    },
+  ): void; // atomic re-expand; throws AppError(404) if absent
 }
 
 export interface SettingsRepository {

--- a/src/infra/composition.ts
+++ b/src/infra/composition.ts
@@ -67,7 +67,11 @@ export function buildContainer(db: Db): Container {
       cards: repositories.cards,
       installments: repositories.installments,
     }),
-    installments: makeInstallmentUseCases({ installments: repositories.installments }),
+    installments: makeInstallmentUseCases({
+      installments: repositories.installments,
+      categories: repositories.categories,
+      cards: repositories.cards,
+    }),
     categories: makeCategoryUseCases({
       categories: repositories.categories,
       groups: repositories.groups,

--- a/src/infra/repositories/installments.ts
+++ b/src/infra/repositories/installments.ts
@@ -62,6 +62,20 @@ export function makeInstallmentRepository(db: Db): InstallmentRepository {
       });
       tx();
     },
+    payOffEarly(id, asOfMonth): void {
+      const tx = db.transaction(() => {
+        const exists = db.prepare('SELECT id FROM installment_groups WHERE id=?').get(id);
+        if (!exists) throw new AppError(404, 'installment group not found');
+        const r = db
+          .prepare(
+            `UPDATE transactions SET date=@date
+           WHERE installment_group_id=@id AND strftime('%Y-%m', date) > @asOf`,
+          )
+          .run({ date: `${asOfMonth}-01`, id, asOf: asOfMonth });
+        if (r.changes === 0) throw new AppError(400, 'no future parcelas to pay off');
+      });
+      tx();
+    },
     listWithProgress(asOfMonth: string) {
       return db
         .prepare(

--- a/src/infra/repositories/installments.ts
+++ b/src/infra/repositories/installments.ts
@@ -38,5 +38,24 @@ export function makeInstallmentRepository(db: Db): InstallmentRepository {
       });
       tx();
     },
+    listWithProgress(asOfMonth: string) {
+      return db.prepare(
+        `SELECT g.id, g.description, g.category_id, g.card_id,
+                cat.name AS category_name, crd.name AS card_name,
+                g.total_cents, g.total_count, g.first_month,
+                COALESCE(SUM(CASE WHEN strftime('%Y-%m', t.date) <= @asOf THEN 1 ELSE 0 END), 0) AS paid_count,
+                COALESCE(SUM(CASE WHEN strftime('%Y-%m', t.date) >  @asOf THEN 1 ELSE 0 END), 0) AS remaining_count,
+                COALESCE(SUM(CASE WHEN strftime('%Y-%m', t.date) <= @asOf THEN t.amount_cents ELSE 0 END), 0) AS paid_cents,
+                COALESCE(SUM(CASE WHEN strftime('%Y-%m', t.date) >  @asOf THEN t.amount_cents ELSE 0 END), 0) AS remaining_cents,
+                COALESCE(MAX(t.amount_cents), 0) AS monthly_cents,
+                MIN(CASE WHEN strftime('%Y-%m', t.date) > @asOf THEN strftime('%Y-%m', t.date) END) AS next_month
+         FROM installment_groups g
+         JOIN categories cat ON cat.id = g.category_id
+         JOIN cards crd ON crd.id = g.card_id
+         LEFT JOIN transactions t ON t.installment_group_id = g.id
+         GROUP BY g.id
+         ORDER BY g.first_month, g.id`,
+      ).all({ asOf: asOfMonth }) as import('../../domain/entities').InstallmentProgress[];
+    },
   };
 }

--- a/src/infra/repositories/installments.ts
+++ b/src/infra/repositories/installments.ts
@@ -63,8 +63,9 @@ export function makeInstallmentRepository(db: Db): InstallmentRepository {
       tx();
     },
     listWithProgress(asOfMonth: string) {
-      return db.prepare(
-        `SELECT g.id, g.description, g.category_id, g.card_id,
+      return db
+        .prepare(
+          `SELECT g.id, g.description, g.category_id, g.card_id,
                 cat.name AS category_name, crd.name AS card_name,
                 g.total_cents, g.total_count, g.first_month,
                 COALESCE(SUM(CASE WHEN strftime('%Y-%m', t.date) <= @asOf THEN 1 ELSE 0 END), 0) AS paid_count,
@@ -79,7 +80,8 @@ export function makeInstallmentRepository(db: Db): InstallmentRepository {
          LEFT JOIN transactions t ON t.installment_group_id = g.id
          GROUP BY g.id
          ORDER BY g.first_month, g.id`,
-      ).all({ asOf: asOfMonth }) as import('../../domain/entities').InstallmentProgress[];
+        )
+        .all({ asOf: asOfMonth }) as import('../../domain/entities').InstallmentProgress[];
     },
   };
 }

--- a/src/infra/repositories/installments.ts
+++ b/src/infra/repositories/installments.ts
@@ -38,6 +38,30 @@ export function makeInstallmentRepository(db: Db): InstallmentRepository {
       });
       tx();
     },
+    update(id, p): void {
+      const { category_id, card_id, description = '', total_cents, count, first_month } = p;
+      const tx = db.transaction(() => {
+        const exists = db.prepare('SELECT id FROM installment_groups WHERE id=?').get(id);
+        if (!exists) throw new AppError(404, 'installment group not found');
+        db.prepare('DELETE FROM transactions WHERE installment_group_id=?').run(id);
+        db.prepare(
+          `UPDATE installment_groups
+           SET description=?, total_cents=?, total_count=?, first_month=?, category_id=?, card_id=?
+           WHERE id=?`,
+        ).run(description, total_cents, count, first_month, category_id, card_id, id);
+        const amounts = splitCents(total_cents, count);
+        const insert = db.prepare(
+          `INSERT INTO transactions (date, category_id, card_id, amount_cents, description,
+            installment_group_id, installment_no, installment_total)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        );
+        amounts.forEach((amt, i) => {
+          const month = addMonths(first_month, i);
+          insert.run(`${month}-01`, category_id, card_id, amt, description, id, i + 1, count);
+        });
+      });
+      tx();
+    },
     listWithProgress(asOfMonth: string) {
       return db.prepare(
         `SELECT g.id, g.description, g.category_id, g.card_id,

--- a/test/chrome.test.ts
+++ b/test/chrome.test.ts
@@ -3,7 +3,7 @@ const assert = require('node:assert');
 
 test('renderNav', async () => {
   const { renderNav, NAV_ITEMS } = await import('../public/js/chrome.js');
-  assert.equal(NAV_ITEMS.length, 5);
+  assert.equal(NAV_ITEMS.length, 6);
 
   const html = renderNav('/transactions.html');
   // all five labels present

--- a/test/installments.test.ts
+++ b/test/installments.test.ts
@@ -283,6 +283,33 @@ test('use-case update rejects an unknown category with 400', async () => {
     .expect(400);
 });
 
+test('PUT with a non-string description returns 400', async () => {
+  const ctx = makeTestDb();
+  const app = createApp(ctx.db);
+  const made = await request(app)
+    .post('/api/transactions')
+    .send({
+      category_id: ctx.categoryId,
+      card_id: ctx.cardId,
+      description: 'TV',
+      installment_total_cents: 1200,
+      installment_count: 2,
+      first_month: '2026-06',
+    })
+    .expect(201);
+  await request(app)
+    .put(`/api/installment-groups/${made.body.installment_group_id}`)
+    .send({
+      category_id: ctx.categoryId,
+      card_id: ctx.cardId,
+      description: { bad: 1 },
+      total_cents: 1200,
+      count: 2,
+      first_month: '2026-06',
+    })
+    .expect(400);
+});
+
 test('payOffEarly collapses future parcelas into asOf month', () => {
   const ctx = makeTestDb();
   const repo = makeInstallmentRepository(ctx.db);
@@ -305,6 +332,19 @@ test('payOffEarly collapses future parcelas into asOf month', () => {
     )
     .get(id).s;
   assert.equal(aug, 40000); // Aug parcela 10000 + Sep/Oct/Nov 30000 moved in
+  // June and July parcelas must have kept their original dates (strictly-greater boundary).
+  const junCount = ctx.db
+    .prepare(
+      "SELECT COUNT(*) n FROM transactions WHERE installment_group_id=? AND strftime('%Y-%m',date)='2026-06'",
+    )
+    .get(id).n;
+  assert.equal(junCount, 1);
+  const julCount = ctx.db
+    .prepare(
+      "SELECT COUNT(*) n FROM transactions WHERE installment_group_id=? AND strftime('%Y-%m',date)='2026-07'",
+    )
+    .get(id).n;
+  assert.equal(julCount, 1);
 });
 
 test('payOffEarly with nothing left throws 400', () => {

--- a/test/installments.test.ts
+++ b/test/installments.test.ts
@@ -74,6 +74,7 @@ test('deleteInstallmentGroup with non-existent id throws 404', async () => {
 });
 
 const { makeInstallmentRepository } = require('../src/infra/repositories/installments');
+const { AppError } = require('../src/domain/errors');
 
 test('listWithProgress splits paid/remaining by asOf month', () => {
   const ctx = makeTestDb();
@@ -94,4 +95,30 @@ test('listWithProgress splits paid/remaining by asOf month', () => {
   assert.equal(r.remaining_cents, 30000);
   assert.equal(r.monthly_cents, 10000);
   assert.equal(r.next_month, '2026-09');
+});
+
+test('update re-expands children to the new count/total atomically', () => {
+  const ctx = makeTestDb();
+  const repo = makeInstallmentRepository(ctx.db);
+  const id = repo.createPurchase({ category_id: ctx.categoryId, card_id: ctx.cardId,
+    description: 'TV', total_cents: 60000, count: 6, first_month: '2026-06' });
+  repo.update(id, { category_id: ctx.categoryId, card_id: ctx.cardId, description: 'TV',
+    total_cents: 30000, count: 3, first_month: '2026-07' });
+  const all = ctx.db.prepare('SELECT * FROM transactions WHERE installment_group_id=? ORDER BY date').all(id);
+  assert.equal(all.length, 3);
+  assert.deepEqual(all.map(t => t.date.slice(0, 7)), ['2026-07', '2026-08', '2026-09']);
+  assert.equal(all.reduce((s, t) => s + t.amount_cents, 0), 30000);
+  assert.equal(all[0].installment_total, 3);
+  const g = ctx.db.prepare('SELECT * FROM installment_groups WHERE id=?').get(id);
+  assert.equal(g.total_count, 3);
+  assert.equal(g.first_month, '2026-07');
+});
+
+test('update on a missing group throws 404', () => {
+  const ctx = makeTestDb();
+  const repo = makeInstallmentRepository(ctx.db);
+  assert.throws(
+    () => repo.update(9999, { category_id: ctx.categoryId, card_id: ctx.cardId,
+      description: '', total_cents: 1000, count: 2, first_month: '2026-06' }),
+    (e) => e instanceof AppError && e.status === 404);
 });

--- a/test/installments.test.ts
+++ b/test/installments.test.ts
@@ -79,8 +79,14 @@ const { AppError } = require('../src/domain/errors');
 test('listWithProgress splits paid/remaining by asOf month', () => {
   const ctx = makeTestDb();
   const repo = makeInstallmentRepository(ctx.db);
-  const id = repo.createPurchase({ category_id: ctx.categoryId, card_id: ctx.cardId,
-    description: 'Avianca', total_cents: 60000, count: 6, first_month: '2026-06' });
+  const id = repo.createPurchase({
+    category_id: ctx.categoryId,
+    card_id: ctx.cardId,
+    description: 'Avianca',
+    total_cents: 60000,
+    count: 6,
+    first_month: '2026-06',
+  });
   // June, July, Aug landed (<= 2026-08); Sep, Oct, Nov remaining.
   const rows = repo.listWithProgress('2026-08');
   assert.equal(rows.length, 1);
@@ -100,14 +106,34 @@ test('listWithProgress splits paid/remaining by asOf month', () => {
 test('update re-expands children to the new count/total atomically', () => {
   const ctx = makeTestDb();
   const repo = makeInstallmentRepository(ctx.db);
-  const id = repo.createPurchase({ category_id: ctx.categoryId, card_id: ctx.cardId,
-    description: 'TV', total_cents: 60000, count: 6, first_month: '2026-06' });
-  repo.update(id, { category_id: ctx.categoryId, card_id: ctx.cardId, description: 'TV',
-    total_cents: 30000, count: 3, first_month: '2026-07' });
-  const all = ctx.db.prepare('SELECT * FROM transactions WHERE installment_group_id=? ORDER BY date').all(id);
+  const id = repo.createPurchase({
+    category_id: ctx.categoryId,
+    card_id: ctx.cardId,
+    description: 'TV',
+    total_cents: 60000,
+    count: 6,
+    first_month: '2026-06',
+  });
+  repo.update(id, {
+    category_id: ctx.categoryId,
+    card_id: ctx.cardId,
+    description: 'TV',
+    total_cents: 30000,
+    count: 3,
+    first_month: '2026-07',
+  });
+  const all = ctx.db
+    .prepare('SELECT * FROM transactions WHERE installment_group_id=? ORDER BY date')
+    .all(id);
   assert.equal(all.length, 3);
-  assert.deepEqual(all.map(t => t.date.slice(0, 7)), ['2026-07', '2026-08', '2026-09']);
-  assert.equal(all.reduce((s, t) => s + t.amount_cents, 0), 30000);
+  assert.deepEqual(
+    all.map((t) => t.date.slice(0, 7)),
+    ['2026-07', '2026-08', '2026-09'],
+  );
+  assert.equal(
+    all.reduce((s, t) => s + t.amount_cents, 0),
+    30000,
+  );
   assert.equal(all[0].installment_total, 3);
   const g = ctx.db.prepare('SELECT * FROM installment_groups WHERE id=?').get(id);
   assert.equal(g.total_count, 3);
@@ -118,9 +144,17 @@ test('update on a missing group throws 404', () => {
   const ctx = makeTestDb();
   const repo = makeInstallmentRepository(ctx.db);
   assert.throws(
-    () => repo.update(9999, { category_id: ctx.categoryId, card_id: ctx.cardId,
-      description: '', total_cents: 1000, count: 2, first_month: '2026-06' }),
-    (e) => e instanceof AppError && e.status === 404);
+    () =>
+      repo.update(9999, {
+        category_id: ctx.categoryId,
+        card_id: ctx.cardId,
+        description: '',
+        total_cents: 1000,
+        count: 2,
+        first_month: '2026-06',
+      }),
+    (e) => e instanceof AppError && e.status === 404,
+  );
 });
 
 const { makeInstallmentUseCases } = require('../src/application/use-cases/installments');
@@ -130,9 +164,121 @@ const { makeCardRepository } = require('../src/infra/repositories/cards');
 test('use-case list returns progress rows', () => {
   const ctx = makeTestDb();
   const repo = makeInstallmentRepository(ctx.db);
-  repo.createPurchase({ category_id: ctx.categoryId, card_id: ctx.cardId, description: 'A',
-    total_cents: 1200, count: 2, first_month: '2026-06' });
-  const uc = makeInstallmentUseCases({ installments: repo,
-    categories: makeCategoryRepository(ctx.db), cards: makeCardRepository(ctx.db) });
+  repo.createPurchase({
+    category_id: ctx.categoryId,
+    card_id: ctx.cardId,
+    description: 'A',
+    total_cents: 1200,
+    count: 2,
+    first_month: '2026-06',
+  });
+  const uc = makeInstallmentUseCases({
+    installments: repo,
+    categories: makeCategoryRepository(ctx.db),
+    cards: makeCardRepository(ctx.db),
+  });
   assert.equal(uc.list('2026-06').length, 1);
+});
+
+test('GET /api/installment-groups returns progress rows', async () => {
+  const ctx = makeTestDb();
+  const app = createApp(ctx.db);
+  await request(app)
+    .post('/api/transactions')
+    .send({
+      category_id: ctx.categoryId,
+      card_id: ctx.cardId,
+      description: 'Avianca',
+      installment_total_cents: 60000,
+      installment_count: 6,
+      first_month: '2026-06',
+    })
+    .expect(201);
+  const res = await request(app).get('/api/installment-groups?month=2026-08').expect(200);
+  assert.equal(res.body.length, 1);
+  assert.equal(res.body[0].remaining_count, 3);
+  assert.equal(res.body[0].monthly_cents, 10000);
+});
+
+test('PUT /api/installment-groups/:id re-expands the schedule', async () => {
+  const ctx = makeTestDb();
+  const app = createApp(ctx.db);
+  const made = await request(app)
+    .post('/api/transactions')
+    .send({
+      category_id: ctx.categoryId,
+      card_id: ctx.cardId,
+      description: 'TV',
+      installment_total_cents: 60000,
+      installment_count: 6,
+      first_month: '2026-06',
+    })
+    .expect(201);
+  await request(app)
+    .put(`/api/installment-groups/${made.body.installment_group_id}`)
+    .send({
+      category_id: ctx.categoryId,
+      card_id: ctx.cardId,
+      description: 'TV',
+      total_cents: 30000,
+      count: 3,
+      first_month: '2026-07',
+    })
+    .expect(204);
+  const n = ctx.db
+    .prepare('SELECT COUNT(*) n FROM transactions WHERE installment_group_id=?')
+    .get(made.body.installment_group_id).n;
+  assert.equal(n, 3);
+});
+
+test('PUT with a bad month returns 400', async () => {
+  const ctx = makeTestDb();
+  const app = createApp(ctx.db);
+  const made = await request(app)
+    .post('/api/transactions')
+    .send({
+      category_id: ctx.categoryId,
+      card_id: ctx.cardId,
+      description: 'TV',
+      installment_total_cents: 1200,
+      installment_count: 2,
+      first_month: '2026-06',
+    })
+    .expect(201);
+  await request(app)
+    .put(`/api/installment-groups/${made.body.installment_group_id}`)
+    .send({
+      category_id: ctx.categoryId,
+      card_id: ctx.cardId,
+      total_cents: 1200,
+      count: 2,
+      first_month: 'June',
+    })
+    .expect(400);
+});
+
+test('use-case update rejects an unknown category with 400', async () => {
+  const ctx = makeTestDb();
+  const app = createApp(ctx.db);
+  const res = await request(app)
+    .post('/api/transactions')
+    .send({
+      category_id: ctx.categoryId,
+      card_id: ctx.cardId,
+      description: 'X',
+      installment_total_cents: 1200,
+      installment_count: 2,
+      first_month: '2026-06',
+    })
+    .expect(201);
+  await request(app)
+    .put(`/api/installment-groups/${res.body.installment_group_id}`)
+    .send({
+      category_id: 999999,
+      card_id: ctx.cardId,
+      total_cents: 1200,
+      count: 2,
+      first_month: '2026-06',
+    })
+    .expect(400);
 });

--- a/test/installments.test.ts
+++ b/test/installments.test.ts
@@ -282,3 +282,64 @@ test('use-case update rejects an unknown category with 400', async () => {
     })
     .expect(400);
 });
+
+test('payOffEarly collapses future parcelas into asOf month', () => {
+  const ctx = makeTestDb();
+  const repo = makeInstallmentRepository(ctx.db);
+  const id = repo.createPurchase({
+    category_id: ctx.categoryId,
+    card_id: ctx.cardId,
+    description: 'TV',
+    total_cents: 60000,
+    count: 6,
+    first_month: '2026-06',
+  });
+  repo.payOffEarly(id, '2026-08');
+  const rows = repo.listWithProgress('2026-08');
+  assert.equal(rows[0].remaining_count, 0);
+  assert.equal(rows[0].paid_cents, 60000);
+  // August now carries June..Aug parcelas plus the 3 collapsed ones.
+  const aug = ctx.db
+    .prepare(
+      "SELECT COALESCE(SUM(amount_cents),0) s FROM transactions WHERE installment_group_id=? AND strftime('%Y-%m',date)='2026-08'",
+    )
+    .get(id).s;
+  assert.equal(aug, 40000); // Aug parcela 10000 + Sep/Oct/Nov 30000 moved in
+});
+
+test('payOffEarly with nothing left throws 400', () => {
+  const ctx = makeTestDb();
+  const repo = makeInstallmentRepository(ctx.db);
+  const id = repo.createPurchase({
+    category_id: ctx.categoryId,
+    card_id: ctx.cardId,
+    description: 'TV',
+    total_cents: 1200,
+    count: 2,
+    first_month: '2026-06',
+  });
+  assert.throws(
+    () => repo.payOffEarly(id, '2027-01'),
+    (e) => e.status === 400,
+  );
+});
+
+test('POST /api/installment-groups/:id/payoff returns 204', async () => {
+  const ctx = makeTestDb();
+  const app = createApp(ctx.db);
+  const made = await request(app)
+    .post('/api/transactions')
+    .send({
+      category_id: ctx.categoryId,
+      card_id: ctx.cardId,
+      description: 'TV',
+      installment_total_cents: 60000,
+      installment_count: 6,
+      first_month: '2026-06',
+    })
+    .expect(201);
+  await request(app)
+    .post(`/api/installment-groups/${made.body.installment_group_id}/payoff`)
+    .send({ month: '2026-08' })
+    .expect(204);
+});

--- a/test/installments.test.ts
+++ b/test/installments.test.ts
@@ -72,3 +72,26 @@ test('deleteInstallmentGroup with non-existent id throws 404', async () => {
   const app = createApp(ctx.db);
   await request(app).delete('/api/installment-groups/99999').expect(404);
 });
+
+const { makeInstallmentRepository } = require('../src/infra/repositories/installments');
+
+test('listWithProgress splits paid/remaining by asOf month', () => {
+  const ctx = makeTestDb();
+  const repo = makeInstallmentRepository(ctx.db);
+  const id = repo.createPurchase({ category_id: ctx.categoryId, card_id: ctx.cardId,
+    description: 'Avianca', total_cents: 60000, count: 6, first_month: '2026-06' });
+  // June, July, Aug landed (<= 2026-08); Sep, Oct, Nov remaining.
+  const rows = repo.listWithProgress('2026-08');
+  assert.equal(rows.length, 1);
+  const r = rows[0];
+  assert.equal(r.id, id);
+  assert.equal(r.category_name, 'Supermercado');
+  assert.equal(r.card_name, 'Nubank');
+  assert.equal(r.total_count, 6);
+  assert.equal(r.paid_count, 3);
+  assert.equal(r.remaining_count, 3);
+  assert.equal(r.paid_cents, 30000);
+  assert.equal(r.remaining_cents, 30000);
+  assert.equal(r.monthly_cents, 10000);
+  assert.equal(r.next_month, '2026-09');
+});

--- a/test/installments.test.ts
+++ b/test/installments.test.ts
@@ -122,3 +122,17 @@ test('update on a missing group throws 404', () => {
       description: '', total_cents: 1000, count: 2, first_month: '2026-06' }),
     (e) => e instanceof AppError && e.status === 404);
 });
+
+const { makeInstallmentUseCases } = require('../src/application/use-cases/installments');
+const { makeCategoryRepository } = require('../src/infra/repositories/categories');
+const { makeCardRepository } = require('../src/infra/repositories/cards');
+
+test('use-case list returns progress rows', () => {
+  const ctx = makeTestDb();
+  const repo = makeInstallmentRepository(ctx.db);
+  repo.createPurchase({ category_id: ctx.categoryId, card_id: ctx.cardId, description: 'A',
+    total_cents: 1200, count: 2, first_month: '2026-06' });
+  const uc = makeInstallmentUseCases({ installments: repo,
+    categories: makeCategoryRepository(ctx.db), cards: makeCardRepository(ctx.db) });
+  assert.equal(uc.list('2026-06').length, 1);
+});

--- a/test/parcelasRender.test.ts
+++ b/test/parcelasRender.test.ts
@@ -1,0 +1,42 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+
+const row = {
+  id: 1,
+  description: 'Avianca',
+  category_name: 'Viagens',
+  card_name: 'Nubank',
+  total_cents: 60000,
+  total_count: 6,
+  paid_count: 3,
+  remaining_count: 3,
+  paid_cents: 30000,
+  remaining_cents: 30000,
+  monthly_cents: 10000,
+  next_month: '2026-09',
+};
+
+test('renderGroups shows progress, monthly and remaining', async () => {
+  const { renderGroups } = await import('../public/js/parcelas.js');
+  const html = renderGroups([row]);
+  assert.match(html, /Avianca/);
+  assert.match(html, /Viagens/);
+  assert.match(html, /3\/6/); // parcelas paid/total
+  assert.match(html, /R\$ 100,00/); // monthly
+  assert.match(html, /R\$ 300,00/); // remaining balance
+  assert.match(html, /2026-09/); // next charge
+  assert.match(html, /data-edit="1"/);
+  assert.match(html, /data-del="1"/);
+});
+
+test('renderGroups escapes the description', async () => {
+  const { renderGroups } = await import('../public/js/parcelas.js');
+  const html = renderGroups([{ ...row, description: '<x>' }]);
+  assert.doesNotMatch(html, /<x>/);
+  assert.match(html, /&lt;x&gt;/);
+});
+
+test('renderGroups shows an empty state', async () => {
+  const { renderGroups } = await import('../public/js/parcelas.js');
+  assert.match(renderGroups([]), /No installment/);
+});


### PR DESCRIPTION
## Phase 1 — Installments Command-Center ("Parcelas")

Gives installment groups a first-class overview page plus atomic **edit** (re-expand) and **pay-off early**, closing the spec gap where only create/delete existed.

### What's included
- **Repository** (`src/infra/repositories/installments.ts`): `listWithProgress(asOf)` (paid/remaining split by month, monthly = max child, next charge), atomic `update` (re-expand children in one transaction), atomic `payOffEarly` (re-date future parcelas into the asOf month; totals unchanged → reversible via edit).
- **Use-cases**: `list` / `update` with category & card reference checks (→ 400), wired with `categories`+`cards` in composition.
- **HTTP** (`/api/installment-groups`): `GET ?month=YYYY-MM` overview, `PUT /:id` edit (zod schema), `POST /:id/payoff`, alongside existing `DELETE /:id`.
- **Frontend**: new `public/parcelas.html` + `public/js/parcelas.js` (pure `renderGroups`, inline edit form, pay-off & delete actions, XSS-escaped), nav item added.

### Design decisions
- "Paid vs remaining" split by an `asOf` month (≤ asOf = paid, > asOf = remaining); defaults to current month, overridable via `?month=`.
- `monthly_cents` = largest child amount (splitCents puts the remainder cent on early parcelas).
- Pay-off-early collapses the remaining schedule into the current month, leaving `total_cents`/`total_count` intact.

### Verification
- 122 tests pass; coverage **90.01% stmts / 83% branches / 98.67% funcs** (all ≥80%).
- `tsc --noEmit` clean; Biome `check` clean (94 files).
- All 6 plan tasks implemented TDD with per-task spec+quality review; final whole-branch review (opus): **Ready to merge — Yes**, no Critical/Important findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
