### PR TITLE
Phase 2 — Quick Data-Driven Wins (suggested limits, transaction filters, three-state budget meter)

### DIFF
--- a/public/css/tailwind.src.css
+++ b/public/css/tailwind.src.css
@@ -11,6 +11,7 @@
   .meter { @apply h-2 rounded-full bg-line overflow-hidden; }
   .meter-fill { @apply h-full rounded-full bg-sage transition-all; }
   .meter-fill.over { @apply bg-clay-soft; }
+  .meter-fill.approaching { @apply bg-gold-accent; }
   .tag { @apply inline-block text-[10px] font-semibold uppercase tracking-wide px-2 py-0.5 rounded; }
   .tag-sage { @apply bg-sage-soft/20 text-sage; }
   .tag-gold { @apply bg-gold-accent/20 text-gold; }
@@ -19,6 +20,7 @@
   .pill { @apply inline-flex items-center gap-1 text-xs font-semibold px-2.5 py-0.5 rounded-full; }
   .pill-ok { @apply bg-sage-soft/20 text-sage; }
   .pill-over { @apply bg-clay-soft/20 text-clay; }
+  .pill-warn { @apply bg-gold-accent/20 text-gold; }
   .label-caps { @apply text-xs font-semibold uppercase tracking-wide; }
   .step-indicator { @apply flex flex-wrap gap-x-4 gap-y-2 my-3; }
   .step { @apply flex items-center gap-2 text-sm text-ink-mut; }

--- a/public/js/settings.js
+++ b/public/js/settings.js
@@ -227,6 +227,27 @@ if (typeof document !== 'undefined' && document.getElementById('limits')) {
       showError(e.message);
     }
   });
+  async function applySuggestions(field) {
+    try {
+      const sugg = await api.get(`/api/limits/suggestions?month=${$('month').value}`);
+      const byCat = new Map(sugg.map((s) => [s.category_id, s[field]]));
+      $('limits')
+        .querySelectorAll('input[data-cat]')
+        .forEach((inp) => {
+          const v = byCat.get(Number(inp.dataset.cat));
+          if (v !== undefined) {
+            inp.value = (v / 100).toFixed(2);
+            inp.dispatchEvent(new Event('change'));
+          }
+        });
+      updateAllocation();
+    } catch (e) {
+      showError(e.message);
+    }
+  }
+  $('useLastMonth').addEventListener('click', () => applySuggestions('last_month_cents'));
+  $('useAvg3').addEventListener('click', () => applySuggestions('avg3_cents'));
+
   loadSettings();
   loadLimits();
   loadCards();

--- a/public/js/setup.js
+++ b/public/js/setup.js
@@ -164,5 +164,23 @@ if (typeof document !== 'undefined' && document.getElementById('setup')) {
     }
   });
 
+  async function applySuggestions(field) {
+    try {
+      const sugg = await api.get(`/api/limits/suggestions?month=${month}`);
+      const byCat = new Map(sugg.map((s) => [s.category_id, s[field]]));
+      $('limits')
+        .querySelectorAll('input[data-cat]')
+        .forEach((inp) => {
+          const v = byCat.get(Number(inp.dataset.cat));
+          if (v !== undefined) inp.value = (v / 100).toFixed(2);
+        });
+      updateAllocation();
+    } catch (e) {
+      showError(e.message);
+    }
+  }
+  $('setupUseLastMonth').addEventListener('click', () => applySuggestions('last_month_cents'));
+  $('setupUseAvg3').addEventListener('click', () => applySuggestions('avg3_cents'));
+
   load();
 }

--- a/public/js/transactions.js
+++ b/public/js/transactions.js
@@ -34,15 +34,36 @@ async function loadSelectors() {
     .filter((c) => c.active)
     .map((c) => `<option value="${c.id}">${esc(c.name)}</option>`)
     .join('');
+  const opt = (c) => `<option value="${c.id}">${esc(c.name)}</option>`;
+  $('filterCategory').insertAdjacentHTML(
+    'beforeend',
+    cats
+      .filter((c) => c.active)
+      .map(opt)
+      .join(''),
+  );
+  $('filterCard').insertAdjacentHTML(
+    'beforeend',
+    cards
+      .filter((c) => c.active)
+      .map(opt)
+      .join(''),
+  );
 }
 
 async function loadList() {
   try {
     const perPage = Number($('perPage').value);
     const offset = (page - 1) * perPage;
-    const { items: rows, total } = await getPage(
-      `/api/transactions?month=${$('month').value}&limit=${perPage}&offset=${offset}`,
-    );
+    const qs = new URLSearchParams({
+      month: $('month').value,
+      limit: String(perPage),
+      offset: String(offset),
+    });
+    if ($('filterCategory').value) qs.set('category_id', $('filterCategory').value);
+    if ($('filterCard').value) qs.set('card_id', $('filterCard').value);
+    if ($('search').value.trim()) qs.set('q', $('search').value.trim());
+    const { items: rows, total } = await getPage(`/api/transactions?${qs}`);
     const totalPages = Math.max(1, Math.ceil(total / perPage));
     if (page > totalPages) {
       page = totalPages;
@@ -166,6 +187,16 @@ if (typeof document !== 'undefined' && document.getElementById('list')) {
     loadList();
   });
   $('perPage').addEventListener('change', () => {
+    page = 1;
+    loadList();
+  });
+  ['filterCategory', 'filterCard'].forEach((id) => {
+    $(id).addEventListener('change', () => {
+      page = 1;
+      loadList();
+    });
+  });
+  $('search').addEventListener('input', () => {
     page = 1;
     loadList();
   });

--- a/public/js/ui.js
+++ b/public/js/ui.js
@@ -7,13 +7,14 @@ export function currency(cents) {
 export function meterBar(spentCents, limitCents, status) {
   const pct = limitCents > 0 ? Math.min(100, Math.round((spentCents / limitCents) * 100)) : 0;
   const over = status === 'over' || (limitCents > 0 && spentCents > limitCents);
-  return `<div class="meter"><div class="meter-fill${over ? ' over' : ''}" style="width:${pct}%"></div></div>`;
+  const cls = over ? ' over' : status === 'approaching' ? ' approaching' : '';
+  return `<div class="meter"><div class="meter-fill${cls}" style="width:${pct}%"></div></div>`;
 }
 
 export function statusPill(status) {
-  return status === 'over'
-    ? `<span class="pill pill-over">Over</span>`
-    : `<span class="pill pill-ok">OK</span>`;
+  if (status === 'over') return `<span class="pill pill-over">Over</span>`;
+  if (status === 'approaching') return `<span class="pill pill-warn">Close</span>`;
+  return `<span class="pill pill-ok">OK</span>`;
 }
 
 export function groupTag(groupName) {

--- a/public/settings.html
+++ b/public/settings.html
@@ -29,6 +29,10 @@
     </section>
     <section class="paper-card">
       <h2 class="font-display text-xl mb-4">Limits for <span id="monthLabel" class="font-mono text-base"></span></h2>
+      <div class="flex gap-2 mb-3">
+        <button id="useLastMonth" class="btn-ghost text-sm">Use last month</button>
+        <button id="useAvg3" class="btn-ghost text-sm">Use 3-month average</button>
+      </div>
       <table class="w-full text-left"><tbody id="limits"></tbody></table>
     </section>
     <section class="paper-card">

--- a/public/setup.html
+++ b/public/setup.html
@@ -66,6 +66,10 @@
         <div data-step="4" class="mt-6 space-y-4" hidden>
           <h3 class="font-display text-xl">Category limits for <span id="limitsMonth" class="font-mono text-base"></span></h3>
           <p class="text-sm text-ink-mut">A monthly ceiling per category. You can change these any time in Settings.</p>
+          <div class="flex gap-2 mb-3">
+            <button id="setupUseLastMonth" class="btn-ghost text-sm">Use last month</button>
+            <button id="setupUseAvg3" class="btn-ghost text-sm">Use 3-month average</button>
+          </div>
           <table class="w-full text-left"><tbody id="limits"></tbody></table>
           <p id="limitsEmpty" class="text-sm text-ink-mut" hidden>No categories yet — you can add them anytime in Settings.</p>
         </div>

--- a/public/transactions.html
+++ b/public/transactions.html
@@ -15,6 +15,11 @@
       <h1 class="font-display text-2xl">Transactions</h1>
       <input type="month" id="month" class="ml-auto rounded border border-line bg-card px-3 py-2" />
     </div>
+    <div class="flex flex-wrap items-center gap-3 mb-4">
+      <select id="filterCategory" class="rounded border border-line bg-card px-3 py-2"><option value="">All categories</option></select>
+      <select id="filterCard" class="rounded border border-line bg-card px-3 py-2"><option value="">All cards</option></select>
+      <input id="search" type="search" placeholder="Search description" class="rounded border border-line bg-card px-3 py-2" />
+    </div>
     <div id="formCard">
       <form id="form" class="paper-card grid sm:grid-cols-2 lg:grid-cols-3 gap-3 mb-6">
         <label class="field"><span>Date</span><input type="date" id="date" required /></label>

--- a/src/adapters/http/controllers/limits.ts
+++ b/src/adapters/http/controllers/limits.ts
@@ -9,6 +9,11 @@ type LimitUseCases = ReturnType<typeof makeLimitUseCases>;
 export function makeLimitsController(uc: LimitUseCases): express.Router {
   const router = express.Router();
 
+  router.get('/suggestions', (req, res) => {
+    const { month } = parse(monthQuerySchema, req.query);
+    res.json(uc.suggestions(month));
+  });
+
   router.get('/', (req, res) => {
     const { month } = parse(monthQuerySchema, req.query);
     res.json(uc.listForMonth(month));

--- a/src/adapters/http/controllers/transactions.ts
+++ b/src/adapters/http/controllers/transactions.ts
@@ -23,6 +23,7 @@ export function makeTransactionsController(uc: TransactionUseCases): express.Rou
     }
     if (category_id !== undefined) page.categoryId = Number(category_id);
     if (card_id !== undefined) page.cardId = Number(card_id);
+    if (req.query.q !== undefined) page.q = String(req.query.q);
 
     page.limit = null;
     page.offset = 0;

--- a/src/application/use-cases/dashboard.ts
+++ b/src/application/use-cases/dashboard.ts
@@ -1,4 +1,5 @@
 import type { LimitRepository, ReportRepository, SettingsRepository } from '../../domain/ports';
+import { budgetStatus } from '../../domain/services/budget';
 import { addMonths } from '../../domain/services/dates';
 
 export interface DashboardUseCaseDeps {
@@ -48,7 +49,7 @@ export function makeDashboardUseCases(deps: DashboardUseCaseDeps) {
           carry_in_cents,
           effective_spent_cents,
           remaining_cents: limit_cents - effective_spent_cents,
-          status: effective_spent_cents > limit_cents ? 'over' : 'ok',
+          status: budgetStatus(effective_spent_cents, limit_cents),
         };
       });
 

--- a/src/application/use-cases/limits.ts
+++ b/src/application/use-cases/limits.ts
@@ -8,7 +8,11 @@ export interface LimitUseCaseDeps {
   reports: ReportRepository;
 }
 
-export interface LimitSuggestion { category_id: number; last_month_cents: number; avg3_cents: number; }
+export interface LimitSuggestion {
+  category_id: number;
+  last_month_cents: number;
+  avg3_cents: number;
+}
 
 export interface ResolvedLimit {
   category_id: number;
@@ -43,7 +47,7 @@ export function makeLimitUseCases(deps: LimitUseCaseDeps) {
       const m1 = addMonths(month, -1);
       const m2 = addMonths(month, -2);
       const m3 = addMonths(month, -3);
-      return categories.listActive().map(c => {
+      return categories.listActive().map((c) => {
         const a = reports.spendByCategoryMonth(c.id, m1);
         const b = reports.spendByCategoryMonth(c.id, m2);
         const d = reports.spendByCategoryMonth(c.id, m3);

--- a/src/application/use-cases/limits.ts
+++ b/src/application/use-cases/limits.ts
@@ -1,10 +1,14 @@
 import { AppError } from '../../domain/errors';
-import type { CategoryRepository, LimitRepository } from '../../domain/ports';
+import type { CategoryRepository, LimitRepository, ReportRepository } from '../../domain/ports';
+import { addMonths } from '../../domain/services/dates';
 
 export interface LimitUseCaseDeps {
   limits: LimitRepository;
   categories: CategoryRepository;
+  reports: ReportRepository;
 }
+
+export interface LimitSuggestion { category_id: number; last_month_cents: number; avg3_cents: number; }
 
 export interface ResolvedLimit {
   category_id: number;
@@ -18,7 +22,7 @@ export interface UpsertLimitInput {
 }
 
 export function makeLimitUseCases(deps: LimitUseCaseDeps) {
-  const { limits, categories } = deps;
+  const { limits, categories, reports } = deps;
   return {
     // Resolved limit per active category for the month (carry-forward).
     // Uses listActiveIds() (no ORDER BY) to preserve the legacy array ordering.
@@ -34,6 +38,17 @@ export function makeLimitUseCases(deps: LimitUseCaseDeps) {
         throw new AppError(400, 'category_id does not exist');
       limits.upsert(input.category_id, input.month, input.limit_cents);
       return { category_id: input.category_id, month: input.month, limit_cents: input.limit_cents };
+    },
+    suggestions(month: string): LimitSuggestion[] {
+      const m1 = addMonths(month, -1);
+      const m2 = addMonths(month, -2);
+      const m3 = addMonths(month, -3);
+      return categories.listActive().map(c => {
+        const a = reports.spendByCategoryMonth(c.id, m1);
+        const b = reports.spendByCategoryMonth(c.id, m2);
+        const d = reports.spendByCategoryMonth(c.id, m3);
+        return { category_id: c.id, last_month_cents: a, avg3_cents: Math.round((a + b + d) / 3) };
+      });
     },
   };
 }

--- a/src/application/use-cases/transactions.ts
+++ b/src/application/use-cases/transactions.ts
@@ -46,7 +46,12 @@ export function makeTransactionUseCases(deps: TransactionUseCaseDeps) {
 
   return {
     list(page: TransactionPage): { total: number; items: Transaction[] } {
-      const filter = { month: page.month, categoryId: page.categoryId, cardId: page.cardId };
+      const filter = {
+        month: page.month,
+        categoryId: page.categoryId,
+        cardId: page.cardId,
+        q: page.q,
+      };
       return { total: transactions.count(filter), items: transactions.list(page) };
     },
 

--- a/src/domain/ports/index.ts
+++ b/src/domain/ports/index.ts
@@ -38,6 +38,7 @@ export interface TransactionFilter {
   month?: string;
   categoryId?: number;
   cardId?: number;
+  q?: string;
 }
 export interface TransactionPage extends TransactionFilter {
   limit?: number | null;

--- a/src/domain/services/budget.ts
+++ b/src/domain/services/budget.ts
@@ -1,0 +1,11 @@
+export type BudgetStatus = 'ok' | 'approaching' | 'over';
+
+export function budgetStatus(
+  spentCents: number,
+  limitCents: number,
+  approachAt = 0.8,
+): BudgetStatus {
+  if (limitCents > 0 && spentCents > limitCents) return 'over';
+  if (limitCents > 0 && spentCents >= limitCents * approachAt) return 'approaching';
+  return 'ok';
+}

--- a/src/infra/composition.ts
+++ b/src/infra/composition.ts
@@ -78,7 +78,9 @@ export function buildContainer(db: Db): Container {
     }),
     groups: makeGroupUseCases({ groups: repositories.groups }),
     cards: makeCardUseCases({ cards: repositories.cards }),
-    limits: makeLimitUseCases({ limits: repositories.limits, categories: repositories.categories }),
+    limits: makeLimitUseCases({
+      limits: repositories.limits, categories: repositories.categories, reports: repositories.reports,
+    }),
     settings: makeSettingsUseCases({ settings: repositories.settings }),
     onboarding: makeOnboardingUseCases({ settings: repositories.settings }),
     dashboard: makeDashboardUseCases({

--- a/src/infra/composition.ts
+++ b/src/infra/composition.ts
@@ -79,7 +79,9 @@ export function buildContainer(db: Db): Container {
     groups: makeGroupUseCases({ groups: repositories.groups }),
     cards: makeCardUseCases({ cards: repositories.cards }),
     limits: makeLimitUseCases({
-      limits: repositories.limits, categories: repositories.categories, reports: repositories.reports,
+      limits: repositories.limits,
+      categories: repositories.categories,
+      reports: repositories.reports,
     }),
     settings: makeSettingsUseCases({ settings: repositories.settings }),
     onboarding: makeOnboardingUseCases({ settings: repositories.settings }),

--- a/src/infra/repositories/transactions.ts
+++ b/src/infra/repositories/transactions.ts
@@ -17,6 +17,10 @@ function buildWhere(f: TransactionFilter): { clause: string; args: unknown[] } {
     where.push('card_id = ?');
     args.push(f.cardId);
   }
+  if (f.q !== undefined && f.q !== '') {
+    where.push('description LIKE ?');
+    args.push(`%${f.q}%`);
+  }
   return { clause: where.length ? `WHERE ${where.join(' AND ')}` : '', args };
 }
 

--- a/test/budgetStatus.test.ts
+++ b/test/budgetStatus.test.ts
@@ -1,0 +1,11 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { budgetStatus } = require('../src/domain/services/budget');
+
+test('budgetStatus is over above limit, approaching from 80%, else ok', () => {
+  assert.equal(budgetStatus(101, 100), 'over');
+  assert.equal(budgetStatus(100, 100), 'approaching'); // at the limit
+  assert.equal(budgetStatus(80, 100), 'approaching');
+  assert.equal(budgetStatus(79, 100), 'ok');
+  assert.equal(budgetStatus(50, 0), 'ok'); // no limit set
+});

--- a/test/dashboardRender.test.ts
+++ b/test/dashboardRender.test.ts
@@ -122,6 +122,31 @@ test('renderGroups omits carryover badge when not carrying', async () => {
   assert.doesNotMatch(html, /carryover/);
 });
 
+test('renderGroups shows approaching meter and warn pill', async () => {
+  const { renderGroups } = await import('../public/js/dashboard.js');
+  const d = {
+    categories: [
+      {
+        category_id: 3,
+        name: 'Lazer',
+        examples: '',
+        group_id: 1,
+        group_name: 'Estilo de vida',
+        limit_cents: 10000,
+        spent_cents: 8500,
+        status: 'approaching',
+      },
+    ],
+    groups: [{ group_id: 1, name: 'Estilo de vida', limit_cents: 10000, spent_cents: 8500 }],
+    totals: {},
+  };
+  const html = renderGroups(d);
+  assert.match(html, /meter-fill approaching/);
+  assert.doesNotMatch(html, /meter-fill over/);
+  assert.match(html, /pill-warn/);
+  assert.match(html, /Close/);
+});
+
 test('renderGroups links each category to its detail screen', async () => {
   const { renderGroups } = await import('../public/js/dashboard.js');
   const html = renderGroups({ ...data, month: '2026-06' });

--- a/test/limitSuggestions.test.ts
+++ b/test/limitSuggestions.test.ts
@@ -1,0 +1,20 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const request = require('supertest');
+const { makeTestDb } = require('./helpers');
+const { createApp } = require('../src/app');
+
+test('GET /api/limits/suggestions returns last-month and 3-month average', async () => {
+  const ctx = makeTestDb();
+  const app = createApp(ctx.db);
+  const tx = (date, cents) => request(app).post('/api/transactions')
+    .send({ date, category_id: ctx.categoryId, card_id: ctx.cardId, amount_cents: cents, description: 'x' })
+    .expect(201);
+  await tx('2026-03-10', 30000); // 3 months before June
+  await tx('2026-04-10', 60000);
+  await tx('2026-05-10', 90000); // last month before June
+  const res = await request(app).get('/api/limits/suggestions?month=2026-06').expect(200);
+  const row = res.body.find(r => r.category_id === ctx.categoryId);
+  assert.equal(row.last_month_cents, 90000);
+  assert.equal(row.avg3_cents, 60000); // (30000+60000+90000)/3
+});

--- a/test/limitSuggestions.test.ts
+++ b/test/limitSuggestions.test.ts
@@ -7,14 +7,22 @@ const { createApp } = require('../src/app');
 test('GET /api/limits/suggestions returns last-month and 3-month average', async () => {
   const ctx = makeTestDb();
   const app = createApp(ctx.db);
-  const tx = (date, cents) => request(app).post('/api/transactions')
-    .send({ date, category_id: ctx.categoryId, card_id: ctx.cardId, amount_cents: cents, description: 'x' })
-    .expect(201);
+  const tx = (date, cents) =>
+    request(app)
+      .post('/api/transactions')
+      .send({
+        date,
+        category_id: ctx.categoryId,
+        card_id: ctx.cardId,
+        amount_cents: cents,
+        description: 'x',
+      })
+      .expect(201);
   await tx('2026-03-10', 30000); // 3 months before June
   await tx('2026-04-10', 60000);
   await tx('2026-05-10', 90000); // last month before June
   const res = await request(app).get('/api/limits/suggestions?month=2026-06').expect(200);
-  const row = res.body.find(r => r.category_id === ctx.categoryId);
+  const row = res.body.find((r) => r.category_id === ctx.categoryId);
   assert.equal(row.last_month_cents, 90000);
   assert.equal(row.avg3_cents, 60000); // (30000+60000+90000)/3
 });

--- a/test/transactions.test.ts
+++ b/test/transactions.test.ts
@@ -103,3 +103,24 @@ test('transactions: get filters and delete 404', async () => {
   const r = await request(app).get(`/api/transactions?category_id=${ctx.categoryId}`).expect(200);
   assert.equal(r.body.length, 1);
 });
+
+test('GET /api/transactions filters by description q', async () => {
+  const ctx = makeTestDb();
+  const app = createApp(ctx.db);
+  const add = (d) =>
+    request(app)
+      .post('/api/transactions')
+      .send({
+        date: '2026-06-01',
+        category_id: ctx.categoryId,
+        card_id: ctx.cardId,
+        amount_cents: 100,
+        description: d,
+      })
+      .expect(201);
+  await add('Coffee at Starbucks');
+  await add('Groceries');
+  const res = await request(app).get('/api/transactions?q=coffee').expect(200);
+  assert.equal(res.body.length, 1);
+  assert.match(res.body[0].description, /Coffee/);
+});

--- a/test/ui.test.ts
+++ b/test/ui.test.ts
@@ -32,3 +32,15 @@ test('ui helpers', async () => {
   assert.match(ui.groupTag('Fundos'), /tag-slate/);
   assert.match(ui.groupTag('Folga'), /tag-neutral/);
 });
+
+test('statusPill renders a warn pill when approaching', async () => {
+  const { statusPill } = await import('../public/js/ui.js');
+  assert.match(statusPill('approaching'), /pill-warn/);
+  assert.match(statusPill('approaching'), /Close/);
+});
+
+test('meterBar marks the approaching fill', async () => {
+  const { meterBar } = await import('../public/js/ui.js');
+  assert.match(meterBar(85, 100, 'approaching'), /meter-fill approaching/);
+  assert.doesNotMatch(meterBar(85, 100, 'approaching'), /over/);
+});


### PR DESCRIPTION
## Summary

Three small, high-leverage improvements, each a thin vertical slice over existing services:

1. **Suggested category limits from history** — `LimitUseCases.suggestions(month)` over `ReportRepository.spendByCategoryMonth` + `GET /api/limits/suggestions?month=YYYY-MM`, surfaced as one-click **"Use last month"** / **"Use 3-month average"** buttons on Settings and Setup.
2. **Transaction filters** — description search `?q=` (bound `LIKE`, threaded port→repo→use-case→controller) plus category/card dropdowns and a search box on the Transactions page.
3. **Three-state budget meter** — new pure `budgetStatus(spent, limit, approachAt=0.8): 'ok'|'approaching'|'over'` domain helper wired into the dashboard, with a gold "approaching" meter fill and a **"Close"** warn pill in the shared renderers.

## Tasks (each TDD where applicable, reviewed per-task)

- Task 1: `suggestions` use-case + route + `reports` DI (`804e12f`)
- Task 2: suggested-limit buttons, Settings + Setup (`ee6c902`)
- Task 3: `q` description-search filter API (`011b2c0`)
- Task 4: category/card/search filter controls (`958b13c`)
- Task 5: `budgetStatus` helper + dashboard rewire (`c02b9f3`)
- Task 6: three-state `meterBar`/`statusPill` + `.pill-warn`/`.meter-fill.approaching` CSS (`4cabb7b`)

## Verification

- **128/128 tests pass**; coverage 90.21% statements / 83.19% branches / 98.69% functions (≥80% gate).
- Typecheck + Biome lint clean.
- Live API smoke: suggestions route returns the integer-cent `LimitSuggestion` shape (zero-spend safe via `COALESCE`), `?q=` filters, and a malformed `?month` returns 400.
- Final whole-branch review (opus): **Ready to merge — Yes**; no Critical/Important findings. The three logged Minors (redundant `over` recompute in `meterBar`; `%`/`_` LIKE-wildcard passthrough; `String(q)` on repeated params) are cosmetic and deferred.

## Notes

Per the plan, the two-state status in `dashboard.js` totals row, `category.js` `renderSummary`, and the simulate use-case is intentionally left as a follow-up — adopting the three-state helper there is out of this phase's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)