### PR TITLE
Phase 3 — Recurring Transactions & Savings History

### DIFF
--- a/migrations/004_recurring.sql
+++ b/migrations/004_recurring.sql
@@ -1,0 +1,12 @@
+CREATE TABLE recurring_templates (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  description TEXT NOT NULL DEFAULT '',
+  category_id INTEGER NOT NULL REFERENCES categories(id),
+  card_id INTEGER NOT NULL REFERENCES cards(id),
+  amount_cents INTEGER NOT NULL,
+  day_of_month INTEGER NOT NULL DEFAULT 1,
+  active INTEGER NOT NULL DEFAULT 1
+);
+
+ALTER TABLE transactions ADD COLUMN recurring_template_id INTEGER REFERENCES recurring_templates(id);
+CREATE INDEX idx_tx_recurring ON transactions(recurring_template_id);

--- a/public/bi.html
+++ b/public/bi.html
@@ -25,6 +25,11 @@
       <div class="paper-card"><h2 class="font-display text-lg mb-2">Budget vs actual</h2><canvas id="budgetVsActual" height="140"></canvas></div>
       <div class="paper-card"><h2 class="font-display text-lg mb-2">Committed installment forecast</h2><canvas id="installmentForecast" height="140"></canvas></div>
     </div>
+    <section class="paper-card mt-6">
+      <h2 class="font-display text-xl mb-1">Savings over time</h2>
+      <p class="text-xs text-ink-mut mb-3">Projected savings (income − fixed − spend) vs goal, using current settings.</p>
+      <canvas id="savingsTrend"></canvas>
+    </section>
   </main>
   <script type="module" src="/js/bi.js"></script>
 </body>

--- a/public/bi.html
+++ b/public/bi.html
@@ -28,7 +28,7 @@
     <section class="paper-card mt-6">
       <h2 class="font-display text-xl mb-1">Savings over time</h2>
       <p class="text-xs text-ink-mut mb-3">Projected savings (income − fixed − spend) vs goal, using current settings.</p>
-      <canvas id="savingsTrend"></canvas>
+      <canvas id="savingsTrend" height="140"></canvas>
     </section>
   </main>
   <script type="module" src="/js/bi.js"></script>

--- a/public/js/bi.js
+++ b/public/js/bi.js
@@ -6,18 +6,20 @@ import { addMonths, currentMonth } from './format.js';
 async function run() {
   try {
     const qs = `from=${document.getElementById('from').value}&to=${document.getElementById('to').value}`;
-    const [trends, byCard, byGroup, bva, forecast] = await Promise.all([
+    const [trends, byCard, byGroup, bva, forecast, savings] = await Promise.all([
       api.get(`/api/bi/trends?${qs}`),
       api.get(`/api/bi/by-card?${qs}`),
       api.get(`/api/bi/by-group?${qs}`),
       api.get(`/api/bi/budget-vs-actual?${qs}`),
       api.get(`/api/bi/installment-forecast?${qs}`),
+      api.get(`/api/bi/savings-trend?${qs}`),
     ]);
     lineChart('chart', trends.months, trends.series, true);
     lineChart('byCard', byCard.months, byCard.series, false);
     lineChart('byGroup', byGroup.months, byGroup.series, false);
     lineChart('budgetVsActual', bva.months, bva.series, false);
     lineChart('installmentForecast', forecast.months, forecast.series, false);
+    lineChart('savingsTrend', savings.months, savings.series, false);
   } catch (e) {
     showError(e.message);
   }

--- a/public/js/chrome.js
+++ b/public/js/chrome.js
@@ -2,6 +2,7 @@ export const NAV_ITEMS = [
   { href: '/', label: 'Dashboard', route: '/' },
   { href: '/transactions.html', label: 'Transactions', route: '/transactions.html' },
   { href: '/parcelas.html', label: 'Parcelas', route: '/parcelas.html' },
+  { href: '/recurring.html', label: 'Recurring', route: '/recurring.html' },
   { href: '/settings.html', label: 'Settings', route: '/settings.html' },
   { href: '/bi.html', label: 'BI', route: '/bi.html' },
   { href: '/simulate.html', label: 'Simulate', route: '/simulate.html' },

--- a/public/js/recurring.js
+++ b/public/js/recurring.js
@@ -1,0 +1,98 @@
+import { api, showError } from './api.js';
+import { mountChrome } from './chrome.js';
+import { currentMonth, esc, formatBRL } from './format.js';
+
+const $ = (id) => document.getElementById(id);
+let names = { cats: new Map(), cards: new Map() };
+
+export function renderList(rows, n) {
+  if (!rows.length) return `<p class="paper-card text-ink-mut">No recurring templates yet.</p>`;
+  return rows
+    .filter((r) => r.active)
+    .map(
+      (r) => `
+    <div class="paper-card flex items-center justify-between">
+      <div>
+        <div class="font-semibold">${esc(r.description) || 'Recurring'}</div>
+        <div class="text-xs text-ink-mut">${esc(n.cats.get(r.category_id) || '')} · ${esc(n.cards.get(r.card_id) || '')} · day ${r.day_of_month}</div>
+      </div>
+      <div class="text-right">
+        <div class="font-mono">${formatBRL(r.amount_cents)}</div>
+        <button data-del="${r.id}" class="text-clay text-sm">Remove</button>
+      </div>
+    </div>`,
+    )
+    .join('');
+}
+
+async function load() {
+  try {
+    const [rows, cats, cards] = await Promise.all([
+      api.get('/api/recurring'),
+      api.get('/api/categories'),
+      api.get('/api/cards'),
+    ]);
+    names = {
+      cats: new Map(cats.map((c) => [c.id, c.name])),
+      cards: new Map(cards.map((c) => [c.id, c.name])),
+    };
+    $('list').innerHTML = renderList(rows, names);
+    $('list')
+      .querySelectorAll('button[data-del]')
+      .forEach((b) => {
+        b.addEventListener('click', async () => {
+          try {
+            await api.del(`/api/recurring/${b.dataset.del}`);
+            load();
+          } catch (e) {
+            showError(e.message);
+          }
+        });
+      });
+    $('category').innerHTML = cats
+      .filter((c) => c.active)
+      .map((c) => `<option value="${c.id}">${esc(c.name)}</option>`)
+      .join('');
+    $('card').innerHTML = cards
+      .filter((c) => c.active)
+      .map((c) => `<option value="${c.id}">${esc(c.name)}</option>`)
+      .join('');
+  } catch (e) {
+    showError(e.message);
+  }
+}
+
+if (typeof document !== 'undefined' && document.getElementById('list')) {
+  mountChrome('/recurring.html');
+  $('month').value = currentMonth();
+  $('addForm').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    try {
+      await api.post('/api/recurring', {
+        description: $('description').value,
+        category_id: Number($('category').value),
+        card_id: Number($('card').value),
+        amount_cents: Math.round(Number($('amount').value) * 100),
+        day_of_month: Number($('day').value),
+      });
+      $('addForm').reset();
+      load();
+    } catch (err) {
+      showError(err.message);
+    }
+  });
+  $('materialize').addEventListener('click', async () => {
+    try {
+      const r = await api.post('/api/recurring/materialize', { month: $('month').value });
+      const changed = r.changed
+        .map((c) => `${formatBRL(c.from_cents)}→${formatBRL(c.to_cents)}`)
+        .join(', ');
+      showError(
+        `Created ${r.created.length}, skipped ${r.skipped.length}${changed ? ` · changed: ${changed}` : ''}`,
+      );
+    } catch (e) {
+      showError(e.message);
+    }
+  });
+  load();
+}

--- a/public/recurring.html
+++ b/public/recurring.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Gastando — Recurring</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@600;700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="/css/app.css" />
+</head>
+<body class="pb-24 md:pb-0">
+  <div id="nav"></div>
+  <main class="max-w-5xl mx-auto px-6 pt-2">
+    <div class="flex items-center gap-3 mb-4">
+      <h1 class="font-display text-2xl">Recurring Templates</h1>
+      <div class="ml-auto flex items-center gap-3">
+        <input type="month" id="month" class="rounded border border-line bg-card px-3 py-2" />
+        <button id="materialize" class="btn-primary">Materialize this month</button>
+      </div>
+    </div>
+
+    <div id="list" class="mb-6"></div>
+
+    <div class="paper-card">
+      <h2 class="font-display text-lg mb-4">Add Recurring Template</h2>
+      <form id="addForm" class="grid sm:grid-cols-2 lg:grid-cols-3 gap-3">
+        <label class="field"><span>Description</span><input type="text" id="description" /></label>
+        <label class="field"><span>Category</span><select id="category"></select></label>
+        <label class="field"><span>Card</span><select id="card"></select></label>
+        <label class="field"><span>Amount (R$)</span><input type="number" id="amount" step="0.01" min="0" /></label>
+        <label class="field"><span>Day of month (1–31)</span><input type="number" id="day" min="1" max="31" /></label>
+        <div class="flex gap-2 self-end">
+          <button type="submit" class="btn-primary">Add</button>
+        </div>
+      </form>
+    </div>
+  </main>
+  <script type="module" src="/js/recurring.js"></script>
+</body>
+</html>

--- a/src/adapters/http/controllers/bi.ts
+++ b/src/adapters/http/controllers/bi.ts
@@ -31,6 +31,10 @@ export function makeBiController(uc: BiUseCases): express.Router {
     const { from, to } = range(req);
     res.json(uc.installmentForecast(from, to));
   });
+  router.get('/savings-trend', (req, res) => {
+    const { from, to } = range(req);
+    res.json(uc.savingsTrend(from, to));
+  });
 
   router.get('/category-trend', (req, res) => {
     const { category_id, from, to } = parse(biCategoryRangeSchema, req.query);

--- a/src/adapters/http/controllers/recurring.ts
+++ b/src/adapters/http/controllers/recurring.ts
@@ -1,0 +1,34 @@
+import express from 'express';
+import type { makeRecurringUseCases } from '../../../application/use-cases/recurring';
+import { materializeSchema, recurringBodySchema } from '../schemas/recurring';
+import { parse } from '../validate';
+
+type RecurringUseCases = ReturnType<typeof makeRecurringUseCases>;
+
+export function makeRecurringController(uc: RecurringUseCases): express.Router {
+  const router = express.Router();
+
+  router.get('/', (_req, res) => res.json(uc.list()));
+
+  router.post('/materialize', (req, res) => {
+    const { month } = parse(materializeSchema, req.body);
+    res.json(uc.materialize(month));
+  });
+
+  router.post('/', (req, res) => {
+    parse(recurringBodySchema, req.body);
+    res.status(201).json(uc.create(req.body));
+  });
+
+  router.put('/:id', (req, res) => {
+    parse(recurringBodySchema, req.body);
+    res.json(uc.update(Number(req.params.id), req.body));
+  });
+
+  router.delete('/:id', (req, res) => {
+    uc.remove(Number(req.params.id));
+    res.status(204).end();
+  });
+
+  return router;
+}

--- a/src/adapters/http/schemas/recurring.ts
+++ b/src/adapters/http/schemas/recurring.ts
@@ -7,6 +7,7 @@ const dayOfMonth = z.custom<number>(
 );
 
 export const recurringBodySchema = z.object({
+  description: z.string().optional(),
   category_id: zPositiveInt('category_id must be a positive integer'),
   card_id: zPositiveInt('card_id must be a positive integer'),
   amount_cents: zPositiveInt('amount_cents must be a positive integer'),

--- a/src/adapters/http/schemas/recurring.ts
+++ b/src/adapters/http/schemas/recurring.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod';
+import { zPositiveInt } from './common';
+
+const dayOfMonth = z.custom<number>(
+  (v) => typeof v === 'number' && Number.isInteger(v) && v >= 1 && v <= 31,
+  { message: 'day_of_month must be an integer 1..31' },
+);
+
+export const recurringBodySchema = z.object({
+  category_id: zPositiveInt('category_id must be a positive integer'),
+  card_id: zPositiveInt('card_id must be a positive integer'),
+  amount_cents: zPositiveInt('amount_cents must be a positive integer'),
+  day_of_month: dayOfMonth,
+});
+
+export const materializeSchema = z.object({
+  month: z.custom<string>((v) => typeof v === 'string' && /^\d{4}-\d{2}$/.test(v), {
+    message: 'month must be YYYY-MM',
+  }),
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -29,6 +29,7 @@ export function createApp(arg: Container | Db): express.Express {
   app.use('/api/dashboard', controllers.dashboard);
   app.use('/api/bi', controllers.bi);
   app.use('/api/simulate', controllers.simulate);
+  app.use('/api/recurring', controllers.recurring);
 
   app.use(express.static(path.join(__dirname, '..', 'public')));
   app.use(errorHandler);

--- a/src/application/use-cases/bi.ts
+++ b/src/application/use-cases/bi.ts
@@ -4,6 +4,7 @@ import type {
   GroupRepository,
   LimitRepository,
   ReportRepository,
+  SettingsRepository,
 } from '../../domain/ports';
 import { monthRange } from '../../domain/services/dates';
 
@@ -13,10 +14,11 @@ export interface BiUseCaseDeps {
   categories: CategoryRepository;
   cards: CardRepository;
   groups: GroupRepository;
+  settings: SettingsRepository;
 }
 
 export function makeBiUseCases(deps: BiUseCaseDeps) {
-  const { reports, limits, categories, cards, groups } = deps;
+  const { reports, limits, categories, cards, groups, settings } = deps;
 
   return {
     trends(from: string, to: string) {
@@ -88,6 +90,25 @@ export function makeBiUseCases(deps: BiUseCaseDeps) {
             spent_cents: months.map((m) => reports.spendByCategoryMonth(categoryId, m)),
           },
           { name: 'Limit', spent_cents: months.map((m) => limits.resolve(categoryId, m)) },
+        ],
+      };
+    },
+
+    savingsTrend(from: string, to: string) {
+      const months = monthRange(from, to);
+      const num = (k: string) => {
+        const v = settings.get(k);
+        return v !== undefined ? Number(v) : 0;
+      };
+      const income = num('monthly_income');
+      const fixed = num('fixed_costs');
+      const goal = num('savings_goal');
+      const projected = months.map((m) => income - fixed - reports.spendAllMonth(m));
+      return {
+        months,
+        series: [
+          { name: 'Projected savings', spent_cents: projected },
+          { name: 'Goal', spent_cents: months.map(() => goal) },
         ],
       };
     },

--- a/src/application/use-cases/recurring.ts
+++ b/src/application/use-cases/recurring.ts
@@ -1,0 +1,89 @@
+import type { RecurringTemplate } from '../../domain/entities';
+import { AppError } from '../../domain/errors';
+import type { CardRepository, CategoryRepository, RecurringRepository } from '../../domain/ports';
+import { chargeDate } from '../../domain/services/dates';
+
+export interface RecurringUseCaseDeps {
+  recurring: RecurringRepository;
+  categories: CategoryRepository;
+  cards: CardRepository;
+}
+export interface RecurringInput {
+  description?: string;
+  category_id: number;
+  card_id: number;
+  amount_cents: number;
+  day_of_month: number;
+}
+export interface MaterializeResult {
+  created: number[];
+  skipped: number[];
+  changed: { template_id: number; from_cents: number; to_cents: number }[];
+}
+
+export function makeRecurringUseCases(deps: RecurringUseCaseDeps) {
+  const { recurring, categories, cards } = deps;
+  function assertRefs(categoryId: number, cardId: number): void {
+    if (!categories.findById(categoryId)) throw new AppError(400, 'category_id does not exist');
+    if (!cards.findById(cardId)) throw new AppError(400, 'card_id does not exist');
+  }
+
+  return {
+    list(): RecurringTemplate[] {
+      return recurring.list();
+    },
+
+    create(input: RecurringInput): RecurringTemplate {
+      assertRefs(input.category_id, input.card_id);
+      return recurring.insert({
+        description: input.description ?? '',
+        category_id: input.category_id,
+        card_id: input.card_id,
+        amount_cents: input.amount_cents,
+        day_of_month: input.day_of_month,
+      });
+    },
+
+    update(id: number, input: RecurringInput): RecurringTemplate {
+      assertRefs(input.category_id, input.card_id);
+      const changes = recurring.update(id, {
+        description: input.description ?? '',
+        category_id: input.category_id,
+        card_id: input.card_id,
+        amount_cents: input.amount_cents,
+        day_of_month: input.day_of_month,
+        active: 1,
+      });
+      if (changes === 0) throw new AppError(404, 'recurring template not found');
+      return recurring.findById(id) as RecurringTemplate;
+    },
+
+    remove(id: number): void {
+      if (recurring.deactivate(id) === 0) throw new AppError(404, 'recurring template not found');
+    },
+
+    materialize(month: string): MaterializeResult {
+      const result: MaterializeResult = { created: [], skipped: [], changed: [] };
+      for (const t of recurring.listActive()) {
+        if (recurring.findChargeForMonth(t.id, month)) {
+          result.skipped.push(t.id);
+          continue;
+        }
+        const last = recurring.lastChargeAmountBefore(t.id, month);
+        recurring.insertCharge({
+          template_id: t.id,
+          date: chargeDate(month, t.day_of_month),
+          category_id: t.category_id,
+          card_id: t.card_id,
+          amount_cents: t.amount_cents,
+          description: t.description,
+        });
+        if (last !== null && last !== t.amount_cents) {
+          result.changed.push({ template_id: t.id, from_cents: last, to_cents: t.amount_cents });
+        }
+        result.created.push(t.id);
+      }
+      return result;
+    },
+  };
+}

--- a/src/domain/entities/index.ts
+++ b/src/domain/entities/index.ts
@@ -61,3 +61,12 @@ export interface Transaction {
   installment_no: number | null;
   installment_total: number | null;
 }
+export interface RecurringTemplate {
+  id: number;
+  description: string;
+  category_id: number;
+  card_id: number;
+  amount_cents: number;
+  day_of_month: number;
+  active: number;
+}

--- a/src/domain/ports/index.ts
+++ b/src/domain/ports/index.ts
@@ -1,4 +1,11 @@
-import type { Card, Category, Group, InstallmentProgress, Transaction } from '../entities';
+import type {
+  Card,
+  Category,
+  Group,
+  InstallmentProgress,
+  RecurringTemplate,
+  Transaction,
+} from '../entities';
 
 export interface GroupRepository {
   listActive(): Group[];
@@ -110,6 +117,41 @@ export interface SettingsRepository {
   countTransactions(): number;
   countInstallmentGroups(): number;
   wipeCategoryData(): void; // atomic: delete limits, categories, groups
+}
+
+export interface RecurringRepository {
+  list(): RecurringTemplate[];
+  listActive(): RecurringTemplate[];
+  findById(id: number): RecurringTemplate | undefined;
+  insert(t: {
+    description: string;
+    category_id: number;
+    card_id: number;
+    amount_cents: number;
+    day_of_month: number;
+  }): RecurringTemplate;
+  update(
+    id: number,
+    t: {
+      description: string;
+      category_id: number;
+      card_id: number;
+      amount_cents: number;
+      day_of_month: number;
+      active: number;
+    },
+  ): number;
+  deactivate(id: number): number;
+  findChargeForMonth(templateId: number, month: string): boolean;
+  insertCharge(c: {
+    template_id: number;
+    date: string;
+    category_id: number;
+    card_id: number;
+    amount_cents: number;
+    description: string;
+  }): number;
+  lastChargeAmountBefore(templateId: number, month: string): number | null;
 }
 
 export interface ReportRepository {

--- a/src/domain/services/dates.ts
+++ b/src/domain/services/dates.ts
@@ -19,3 +19,13 @@ export function monthRange(from: string, to: string): string[] {
   }
   return months;
 }
+
+export function daysInMonth(month: string): number {
+  const [y, m] = month.split('-').map(Number);
+  return new Date(y, m, 0).getDate();
+}
+
+export function chargeDate(month: string, day: number): string {
+  const d = Math.min(Math.max(1, day), daysInMonth(month));
+  return `${month}-${String(d).padStart(2, '0')}`;
+}

--- a/src/infra/composition.ts
+++ b/src/infra/composition.ts
@@ -101,6 +101,7 @@ export function buildContainer(db: Db): Container {
       categories: repositories.categories,
       cards: repositories.cards,
       groups: repositories.groups,
+      settings: repositories.settings,
     }),
     simulate: makeSimulateUseCases({
       categories: repositories.categories,

--- a/src/infra/composition.ts
+++ b/src/infra/composition.ts
@@ -7,6 +7,7 @@ import { makeGroupsController } from '../adapters/http/controllers/groups';
 import { makeInstallmentGroupsController } from '../adapters/http/controllers/installmentGroups';
 import { makeLimitsController } from '../adapters/http/controllers/limits';
 import { makeOnboardingController } from '../adapters/http/controllers/onboarding';
+import { makeRecurringController } from '../adapters/http/controllers/recurring';
 import { makeSettingsController } from '../adapters/http/controllers/settings';
 import { makeSimulateController } from '../adapters/http/controllers/simulate';
 import { makeTransactionsController } from '../adapters/http/controllers/transactions';
@@ -47,6 +48,7 @@ export interface Container {
     dashboard: express.Router;
     bi: express.Router;
     simulate: express.Router;
+    recurring: express.Router;
   };
 }
 
@@ -123,6 +125,7 @@ export function buildContainer(db: Db): Container {
     dashboard: makeDashboardController(useCases.dashboard),
     bi: makeBiController(useCases.bi),
     simulate: makeSimulateController(useCases.simulate),
+    recurring: makeRecurringController(useCases.recurring),
   };
 
   return { db, controllers };

--- a/src/infra/composition.ts
+++ b/src/infra/composition.ts
@@ -18,6 +18,7 @@ import { makeGroupUseCases } from '../application/use-cases/groups';
 import { makeInstallmentUseCases } from '../application/use-cases/installments';
 import { makeLimitUseCases } from '../application/use-cases/limits';
 import { makeOnboardingUseCases } from '../application/use-cases/onboarding';
+import { makeRecurringUseCases } from '../application/use-cases/recurring';
 import { makeSettingsUseCases } from '../application/use-cases/settings';
 import { makeSimulateUseCases } from '../application/use-cases/simulate';
 import { makeTransactionUseCases } from '../application/use-cases/transactions';
@@ -27,6 +28,7 @@ import { makeCategoryRepository } from './repositories/categories';
 import { makeGroupRepository } from './repositories/groups';
 import { makeInstallmentRepository } from './repositories/installments';
 import { makeLimitRepository } from './repositories/limits';
+import { makeRecurringRepository } from './repositories/recurring';
 import { makeReportRepository } from './repositories/reports';
 import { makeSettingsRepository } from './repositories/settings';
 import { makeTransactionRepository } from './repositories/transactions';
@@ -58,6 +60,7 @@ export function buildContainer(db: Db): Container {
     installments: makeInstallmentRepository(db),
     settings: makeSettingsRepository(db),
     reports: makeReportRepository(db),
+    recurring: makeRecurringRepository(db),
   };
 
   const useCases = {
@@ -100,6 +103,11 @@ export function buildContainer(db: Db): Container {
     simulate: makeSimulateUseCases({
       categories: repositories.categories,
       limits: repositories.limits,
+    }),
+    recurring: makeRecurringUseCases({
+      recurring: repositories.recurring,
+      categories: repositories.categories,
+      cards: repositories.cards,
     }),
   };
 

--- a/src/infra/repositories/recurring.ts
+++ b/src/infra/repositories/recurring.ts
@@ -1,0 +1,72 @@
+import type { RecurringTemplate } from '../../domain/entities';
+import type { RecurringRepository } from '../../domain/ports';
+import type { Db } from '../db';
+
+export function makeRecurringRepository(db: Db): RecurringRepository {
+  return {
+    list() {
+      return db
+        .prepare('SELECT * FROM recurring_templates ORDER BY id')
+        .all() as RecurringTemplate[];
+    },
+    listActive() {
+      return db
+        .prepare('SELECT * FROM recurring_templates WHERE active=1 ORDER BY id')
+        .all() as RecurringTemplate[];
+    },
+    findById(id) {
+      return db.prepare('SELECT * FROM recurring_templates WHERE id=?').get(id) as
+        | RecurringTemplate
+        | undefined;
+    },
+    insert(t) {
+      const r = db
+        .prepare(
+          `INSERT INTO recurring_templates (description, category_id, card_id, amount_cents, day_of_month)
+         VALUES (?, ?, ?, ?, ?)`,
+        )
+        .run(t.description, t.category_id, t.card_id, t.amount_cents, t.day_of_month);
+      return db
+        .prepare('SELECT * FROM recurring_templates WHERE id=?')
+        .get(r.lastInsertRowid) as RecurringTemplate;
+    },
+    update(id, t) {
+      return db
+        .prepare(
+          `UPDATE recurring_templates SET description=?, category_id=?, card_id=?, amount_cents=?, day_of_month=?, active=? WHERE id=?`,
+        )
+        .run(t.description, t.category_id, t.card_id, t.amount_cents, t.day_of_month, t.active, id)
+        .changes;
+    },
+    deactivate(id) {
+      return db.prepare('UPDATE recurring_templates SET active=0 WHERE id=?').run(id).changes;
+    },
+    findChargeForMonth(templateId, month) {
+      const row = db
+        .prepare(
+          `SELECT 1 FROM transactions WHERE recurring_template_id=? AND strftime('%Y-%m', date)=? LIMIT 1`,
+        )
+        .get(templateId, month);
+      return row !== undefined;
+    },
+    insertCharge(c) {
+      const r = db
+        .prepare(
+          `INSERT INTO transactions (date, category_id, card_id, amount_cents, description, recurring_template_id)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+        )
+        .run(c.date, c.category_id, c.card_id, c.amount_cents, c.description, c.template_id);
+      return r.lastInsertRowid as number;
+    },
+    lastChargeAmountBefore(templateId, month) {
+      const row = db
+        .prepare(
+          `SELECT amount_cents FROM transactions
+         WHERE recurring_template_id=? AND strftime('%Y-%m', date) < ?
+         ORDER BY date DESC LIMIT 1`,
+        )
+        .get(templateId, month) as { amount_cents: number } | undefined;
+      return row ? row.amount_cents : null;
+    },
+  };
+}

--- a/test/bi.test.ts
+++ b/test/bi.test.ts
@@ -178,3 +178,27 @@ test('bi category-trend validates inputs (400s)', async () => {
     .get(`/api/bi/category-trend?category_id=${ctx.categoryId}&from=2026-08&to=2026-06`)
     .expect(400); // from > to
 });
+
+test('savingsTrend = income - fixed - spend, vs goal', async () => {
+  const ctx = makeTestDb();
+  const app = createApp(ctx.db);
+  await request(app)
+    .put('/api/settings')
+    .send({ monthly_income: 1000000, fixed_costs: 300000, savings_goal: 200000 })
+    .expect(200);
+  await request(app)
+    .post('/api/transactions')
+    .send({
+      date: '2026-06-10',
+      category_id: ctx.categoryId,
+      card_id: ctx.cardId,
+      amount_cents: 100000,
+      description: 'x',
+    })
+    .expect(201);
+  const res = await request(app).get('/api/bi/savings-trend?from=2026-06&to=2026-06').expect(200);
+  const projected = res.body.series.find((s) => s.name === 'Projected savings');
+  const goal = res.body.series.find((s) => s.name === 'Goal');
+  assert.equal(projected.spent_cents[0], 600000); // 1,000,000 - 300,000 - 100,000
+  assert.equal(goal.spent_cents[0], 200000);
+});

--- a/test/chrome.test.ts
+++ b/test/chrome.test.ts
@@ -3,7 +3,7 @@ const assert = require('node:assert');
 
 test('renderNav', async () => {
   const { renderNav, NAV_ITEMS } = await import('../public/js/chrome.js');
-  assert.equal(NAV_ITEMS.length, 6);
+  assert.equal(NAV_ITEMS.length, 7);
 
   const html = renderNav('/transactions.html');
   // all five labels present

--- a/test/dates.test.ts
+++ b/test/dates.test.ts
@@ -1,6 +1,7 @@
 const { test } = require('node:test');
 const assert = require('node:assert');
 const { monthOf, addMonths } = require('../src/domain/services/dates');
+const { daysInMonth, chargeDate } = require('../src/domain/services/dates');
 
 test('monthOf extracts YYYY-MM from a date', () => {
   assert.equal(monthOf('2026-06-15'), '2026-06');
@@ -10,4 +11,11 @@ test('addMonths rolls over years', () => {
   assert.equal(addMonths('2026-06', 0), '2026-06');
   assert.equal(addMonths('2026-11', 2), '2027-01');
   assert.equal(addMonths('2026-01', 12), '2027-01');
+});
+
+test('chargeDate clamps the day to the month length', () => {
+  assert.equal(chargeDate('2026-02', 31), '2026-02-28');
+  assert.equal(chargeDate('2026-06', 5), '2026-06-05');
+  assert.equal(chargeDate('2026-01', 31), '2026-01-31');
+  assert.equal(daysInMonth('2024-02'), 29); // leap year
 });

--- a/test/recurring.test.ts
+++ b/test/recurring.test.ts
@@ -1,0 +1,50 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { makeTestDb } = require('./helpers');
+const { makeRecurringRepository } = require('../src/infra/repositories/recurring');
+
+test('insert + list round-trips a template', () => {
+  const ctx = makeTestDb();
+  const repo = makeRecurringRepository(ctx.db);
+  const t = repo.insert({
+    description: 'Claude',
+    category_id: ctx.categoryId,
+    card_id: ctx.cardId,
+    amount_cents: 10000,
+    day_of_month: 5,
+  });
+  assert.equal(t.description, 'Claude');
+  assert.equal(repo.list().length, 1);
+  assert.equal(repo.listActive().length, 1);
+});
+
+test('charge dedup + last-amount lookup', () => {
+  const ctx = makeTestDb();
+  const repo = makeRecurringRepository(ctx.db);
+  const t = repo.insert({
+    description: 'Disney',
+    category_id: ctx.categoryId,
+    card_id: ctx.cardId,
+    amount_cents: 4000,
+    day_of_month: 1,
+  });
+  assert.equal(repo.findChargeForMonth(t.id, '2026-06'), false);
+  repo.insertCharge({
+    template_id: t.id,
+    date: '2026-05-01',
+    category_id: ctx.categoryId,
+    card_id: ctx.cardId,
+    amount_cents: 3500,
+    description: 'Disney',
+  });
+  assert.equal(repo.lastChargeAmountBefore(t.id, '2026-06'), 3500);
+  repo.insertCharge({
+    template_id: t.id,
+    date: '2026-06-01',
+    category_id: ctx.categoryId,
+    card_id: ctx.cardId,
+    amount_cents: 4000,
+    description: 'Disney',
+  });
+  assert.equal(repo.findChargeForMonth(t.id, '2026-06'), true);
+});

--- a/test/recurring.test.ts
+++ b/test/recurring.test.ts
@@ -2,6 +2,9 @@ const { test } = require('node:test');
 const assert = require('node:assert');
 const { makeTestDb } = require('./helpers');
 const { makeRecurringRepository } = require('../src/infra/repositories/recurring');
+const { makeRecurringUseCases } = require('../src/application/use-cases/recurring');
+const { makeCategoryRepository } = require('../src/infra/repositories/categories');
+const { makeCardRepository } = require('../src/infra/repositories/cards');
 
 test('insert + list round-trips a template', () => {
   const ctx = makeTestDb();
@@ -47,4 +50,56 @@ test('charge dedup + last-amount lookup', () => {
     description: 'Disney',
   });
   assert.equal(repo.findChargeForMonth(t.id, '2026-06'), true);
+});
+
+function ucFor(ctx) {
+  return makeRecurringUseCases({
+    recurring: makeRecurringRepository(ctx.db),
+    categories: makeCategoryRepository(ctx.db),
+    cards: makeCardRepository(ctx.db),
+  });
+}
+
+test('materialize creates one charge per active template and is idempotent', () => {
+  const ctx = makeTestDb();
+  const repo = makeRecurringRepository(ctx.db);
+  const t = repo.insert({
+    description: 'Apple',
+    category_id: ctx.categoryId,
+    card_id: ctx.cardId,
+    amount_cents: 1990,
+    day_of_month: 10,
+  });
+  const uc = ucFor(ctx);
+  const r1 = uc.materialize('2026-06');
+  assert.deepEqual(r1.created, [t.id]);
+  const r2 = uc.materialize('2026-06'); // second run: nothing new
+  assert.deepEqual(r2.created, []);
+  assert.deepEqual(r2.skipped, [t.id]);
+  const row = ctx.db
+    .prepare('SELECT date FROM transactions WHERE recurring_template_id=?')
+    .get(t.id);
+  assert.equal(row.date, '2026-06-10');
+});
+
+test('materialize flags an amount change vs the prior month', () => {
+  const ctx = makeTestDb();
+  const repo = makeRecurringRepository(ctx.db);
+  const t = repo.insert({
+    description: 'Seguro',
+    category_id: ctx.categoryId,
+    card_id: ctx.cardId,
+    amount_cents: 5000,
+    day_of_month: 1,
+  });
+  repo.insertCharge({
+    template_id: t.id,
+    date: '2026-05-01',
+    category_id: ctx.categoryId,
+    card_id: ctx.cardId,
+    amount_cents: 4500,
+    description: 'Seguro',
+  });
+  const r = ucFor(ctx).materialize('2026-06');
+  assert.deepEqual(r.changed, [{ template_id: t.id, from_cents: 4500, to_cents: 5000 }]);
 });

--- a/test/recurring.test.ts
+++ b/test/recurring.test.ts
@@ -147,3 +147,63 @@ test('POST /api/recurring with unknown card -> 400', async () => {
     })
     .expect(400);
 });
+
+test('POST /api/recurring with object description -> 400', async () => {
+  const ctx = makeTestDb();
+  const app = createApp(ctx.db);
+  await request(app)
+    .post('/api/recurring')
+    .send({
+      description: { evil: true },
+      category_id: ctx.categoryId,
+      card_id: ctx.cardId,
+      amount_cents: 100,
+      day_of_month: 1,
+    })
+    .expect(400);
+});
+
+test('PUT /api/recurring/:id updates fields and returns updated template', async () => {
+  const ctx = makeTestDb();
+  const app = createApp(ctx.db);
+  const created = await request(app)
+    .post('/api/recurring')
+    .send({
+      description: 'Spotify',
+      category_id: ctx.categoryId,
+      card_id: ctx.cardId,
+      amount_cents: 2190,
+      day_of_month: 10,
+    })
+    .expect(201);
+
+  const updated = await request(app)
+    .put(`/api/recurring/${created.body.id}`)
+    .send({
+      description: 'Spotify Premium',
+      category_id: ctx.categoryId,
+      card_id: ctx.cardId,
+      amount_cents: 2490,
+      day_of_month: 15,
+    })
+    .expect(200);
+
+  assert.equal(updated.body.amount_cents, 2490);
+  assert.equal(updated.body.day_of_month, 15);
+  assert.equal(updated.body.description, 'Spotify Premium');
+});
+
+test('PUT /api/recurring/99999 (nonexistent) -> 404', async () => {
+  const ctx = makeTestDb();
+  const app = createApp(ctx.db);
+  await request(app)
+    .put('/api/recurring/99999')
+    .send({
+      description: 'Ghost',
+      category_id: ctx.categoryId,
+      card_id: ctx.cardId,
+      amount_cents: 100,
+      day_of_month: 1,
+    })
+    .expect(404);
+});

--- a/test/recurring.test.ts
+++ b/test/recurring.test.ts
@@ -103,3 +103,47 @@ test('materialize flags an amount change vs the prior month', () => {
   const r = ucFor(ctx).materialize('2026-06');
   assert.deepEqual(r.changed, [{ template_id: t.id, from_cents: 4500, to_cents: 5000 }]);
 });
+
+const request = require('supertest');
+const { createApp } = require('../src/app');
+
+test('recurring CRUD + materialize over HTTP', async () => {
+  const ctx = makeTestDb();
+  const app = createApp(ctx.db);
+  const made = await request(app)
+    .post('/api/recurring')
+    .send({
+      description: 'Netflix',
+      category_id: ctx.categoryId,
+      card_id: ctx.cardId,
+      amount_cents: 4590,
+      day_of_month: 15,
+    })
+    .expect(201);
+  assert.equal((await request(app).get('/api/recurring').expect(200)).body.length, 1);
+  const res = await request(app)
+    .post('/api/recurring/materialize')
+    .send({ month: '2026-06' })
+    .expect(200);
+  assert.deepEqual(res.body.created, [made.body.id]);
+  await request(app).delete(`/api/recurring/${made.body.id}`).expect(204);
+  assert.equal(
+    (await request(app).get('/api/recurring').expect(200)).body.filter((t) => t.active).length,
+    0,
+  );
+});
+
+test('POST /api/recurring with unknown card -> 400', async () => {
+  const ctx = makeTestDb();
+  const app = createApp(ctx.db);
+  await request(app)
+    .post('/api/recurring')
+    .send({
+      description: 'X',
+      category_id: ctx.categoryId,
+      card_id: 99999,
+      amount_cents: 100,
+      day_of_month: 1,
+    })
+    .expect(400);
+});

--- a/test/recurringRender.test.ts
+++ b/test/recurringRender.test.ts
@@ -1,0 +1,46 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+
+test('renderList shows description, amount, day and actions', async () => {
+  const { renderList } = await import('../public/js/recurring.js');
+  const names = { cats: new Map([[1, 'Assinaturas']]), cards: new Map([[2, 'Nubank']]) };
+  const html = renderList(
+    [
+      {
+        id: 7,
+        description: 'Claude',
+        category_id: 1,
+        card_id: 2,
+        amount_cents: 10000,
+        day_of_month: 5,
+        active: 1,
+      },
+    ],
+    names,
+  );
+  assert.match(html, /Claude/);
+  assert.match(html, /Assinaturas/);
+  assert.match(html, /R\$ 100,00/);
+  assert.match(html, /day 5/);
+  assert.match(html, /data-del="7"/);
+});
+
+test('renderList escapes the description', async () => {
+  const { renderList } = await import('../public/js/recurring.js');
+  const html = renderList(
+    [
+      {
+        id: 1,
+        description: '<x>',
+        category_id: 1,
+        card_id: 2,
+        amount_cents: 100,
+        day_of_month: 1,
+        active: 1,
+      },
+    ],
+    { cats: new Map(), cards: new Map() },
+  );
+  assert.doesNotMatch(html, /<x>/);
+  assert.match(html, /&lt;x&gt;/);
+});


### PR DESCRIPTION
## Summary

Two features, each a thin vertical slice over the existing hexagonal stack:

### A. Recurring / subscription templates with one-click idempotent materialization
Define recurring charges (description, category, card, amount, day-of-month) and materialize each month's charges in one click. Re-clicking is safe — dedup is enforced by a new `transactions.recurring_template_id` column. Amount changes vs. the most recent prior month's charge are flagged (informational).

### B. Savings over time (BI)
New "Savings over time" chart: per-month `projected_savings = income − fixed − actual_spend(month)` plotted against a flat goal line, using current settings across the range (documented in the chart subtitle).

## Tasks (each TDD where applicable, reviewed per-task)

- Task 1: migration `004` (`recurring_templates` + `recurring_template_id` column + index) + entity + port + repository (`3e74760`)
- Task 2: `daysInMonth`/`chargeDate` helpers + recurring use-case (CRUD + idempotent `materialize`) + composition (`c33f9a8`)
- Task 3: zod schema + thin controller + `/api/recurring` mount (GET/POST/PUT/DELETE + POST /materialize) (`05c4ff7`)
- Task 4: `recurring.html` + `recurring.js` (pure `renderList` + add form + Materialize) + nav item (`bcfb293`)
- Task 5: `BiUseCases.savingsTrend` + `settings` dep + `/api/bi/savings-trend` (`8f83462`)
- Task 6: savings chart card on `bi.html` + `bi.js` draw via existing `lineChart` (`5792dd6`)
- Fix wave: validate `description` in the recurring schema (malformed → 400 not 500), add PUT 200/404 tests, savings canvas height (`0768bab`)

## Design decisions

- Materialization is **manual and idempotent**; dedup key is `(template, month)`. Charge date = template `day_of_month` clamped to month length (Feb/leap-year safe).
- Materialized charges are normal `transactions` rows, so they flow into spend totals, dashboard, and BI automatically (no silo).
- Editing a template never touches already-materialized transactions.
- Savings history applies **current** settings to every month (no historical settings table).

## Verification

- **141/141 tests pass**; coverage 88.3% statements / 83.22% branches / 98.23% functions (≥80% gate).
- Typecheck + Biome lint clean (104 files).
- Live API smoke: recurring CRUD, `materialize` (`created:[1]`) → re-materialize (`created:[], skipped:[1]`, idempotent), malformed `description` → 400, and `savings-trend` returns the correct two-series shape with materialized charges reflected in spend.
- Final whole-branch review (opus): **Ready to merge — Yes**; no Critical/Important findings. The surfaced minors (description schema 400-vs-500, missing PUT test, canvas height) were addressed in the fix wave.

## Notes

A subscription modeled *both* as a recurring template (materialized into transactions) *and* inside `fixed_costs` would be double-counted in the savings projection — a modeling choice, not a defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)