### PR TITLE
Phase 4 — Polish & Bigger Bets (inline Settings, CSV export, SQLite backup, per-card statement)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,11 +118,15 @@ The app reads two environment variables:
 Everything you enter is stored in a single SQLite file, **`data/gastando.db`**.
 There is no other state.
 
-- **Back up** by copying that file:
+- **Back up** by copying that file, or use the **Download backup** button in
+  Settings to download a snapshot from the running app:
 
   ```bash
   cp ./data/gastando.db ./data/gastando.db.bak
   ```
+
+- **Restore** a backup: stop the app, replace `data/gastando.db` with the
+  downloaded backup file, then start the app again.
 
 - **Move or migrate** to another machine by copying the same file into the new
   install's `data/` folder.

--- a/migrations/005_card_statement.sql
+++ b/migrations/005_card_statement.sql
@@ -1,0 +1,2 @@
+ALTER TABLE cards ADD COLUMN closing_day INTEGER;
+ALTER TABLE cards ADD COLUMN due_day INTEGER;

--- a/public/js/budget.js
+++ b/public/js/budget.js
@@ -3,6 +3,14 @@ import { esc, formatBRL } from './format.js';
 // Pure budget-model helpers shared by the Settings page and the setup wizard.
 // Kept free of DOM side-effects so either page can import them safely.
 
+export const GROUP_COLORS = ['sage', 'gold', 'slate', 'neutral'];
+
+export function colorSwatches(groupId, current) {
+  return GROUP_COLORS.map(c =>
+    `<button data-group-color="${groupId}" data-color="${c}" title="${c}"
+       class="tag tag-${c} mr-1 ${c === current ? 'ring-2 ring-ink' : ''}">${c}</button>`).join('');
+}
+
 export function ceilingText(income, fixed, goal) {
   return `Healthy ceiling ${formatBRL(income - fixed - goal)}`;
 }
@@ -47,7 +55,7 @@ export function renderGroupedLimitRows(groups, cats, byCat) {
         <td class="py-2" colspan="2"><span class="tag tag-${esc(g.color)}">${esc(g.name)}</span></td>
         <td class="py-2 text-right">
           <button data-group-rename="${g.id}" class="text-sage text-sm mr-2">Rename</button>
-          <button data-group-recolor="${g.id}" class="text-sage text-sm mr-2">Color</button>
+          ${colorSwatches(g.id, g.color)}
           <button data-group-del="${g.id}" class="text-clay text-sm">Remove</button>
         </td>
       </tr>

--- a/public/js/budget.js
+++ b/public/js/budget.js
@@ -15,9 +15,11 @@ export function nameEditor(kind, id, value) {
 }
 
 export function colorSwatches(groupId, current) {
-  return GROUP_COLORS.map(c =>
-    `<button data-group-color="${groupId}" data-color="${c}" title="${c}"
-       class="tag tag-${c} mr-1 ${c === current ? 'ring-2 ring-ink' : ''}">${c}</button>`).join('');
+  return GROUP_COLORS.map(
+    (c) =>
+      `<button data-group-color="${groupId}" data-color="${c}" title="${c}"
+       class="tag tag-${c} mr-1 ${c === current ? 'ring-2 ring-ink' : ''}">${c}</button>`,
+  ).join('');
 }
 
 export function ceilingText(income, fixed, goal) {

--- a/public/js/budget.js
+++ b/public/js/budget.js
@@ -5,6 +5,15 @@ import { esc, formatBRL } from './format.js';
 
 export const GROUP_COLORS = ['sage', 'gold', 'slate', 'neutral'];
 
+export function nameEditor(kind, id, value) {
+  return `<span class="inline-flex items-center gap-1">
+    <input data-edit-input="${kind}:${id}" value="${esc(value)}"
+      class="rounded border border-line px-2 py-0.5 text-sm" />
+    <button data-save="${kind}:${id}" class="text-sage text-sm">Save</button>
+    <button data-cancel="${kind}:${id}" class="text-ink-mut text-sm">Cancel</button>
+  </span>`;
+}
+
 export function colorSwatches(groupId, current) {
   return GROUP_COLORS.map(c =>
     `<button data-group-color="${groupId}" data-color="${c}" title="${c}"
@@ -38,7 +47,7 @@ export function renderGroupedLimitRows(groups, cats, byCat) {
       .map(
         (c) => `
       <tr class="border-b border-line">
-        <td class="py-2">${esc(c.name)}</td>
+        <td class="py-2" data-name-cell="cat:${c.id}">${esc(c.name)}</td>
         <td class="py-2 text-right">
           <input type="number" step="0.01" data-cat="${c.id}" value="${(byCat.get(c.id) || 0) / 100}"
             class="w-32 rounded border border-line bg-card px-2 py-1 text-right font-mono" />
@@ -52,7 +61,7 @@ export function renderGroupedLimitRows(groups, cats, byCat) {
       .join('');
     return `
       <tr class="bg-paper">
-        <td class="py-2" colspan="2"><span class="tag tag-${esc(g.color)}">${esc(g.name)}</span></td>
+        <td class="py-2" colspan="2" data-name-cell="group:${g.id}"><span class="tag tag-${esc(g.color)}">${esc(g.name)}</span></td>
         <td class="py-2 text-right">
           <button data-group-rename="${g.id}" class="text-sage text-sm mr-2">Rename</button>
           ${colorSwatches(g.id, g.color)}

--- a/public/js/settings.js
+++ b/public/js/settings.js
@@ -87,9 +87,10 @@ async function loadLimits() {
 function beginRename(kind, id) {
   const cell = $('limits').querySelector(`[data-name-cell="${kind}:${id}"]`);
   if (!cell) return;
-  const cur = kind === 'cat'
-    ? state.cats.find((c) => c.id === id).name
-    : state.groups.find((g) => g.id === id).name;
+  const cur =
+    kind === 'cat'
+      ? state.cats.find((c) => c.id === id).name
+      : state.groups.find((g) => g.id === id).name;
   cell.innerHTML = nameEditor(kind, id, cur);
   cell.querySelector('input').focus();
 }
@@ -110,7 +111,10 @@ async function saveEdit(token) {
   const [kind, rawId] = token.split(':');
   const id = rawId;
   const val = $('limits').querySelector(`[data-edit-input="${token}"]`).value.trim();
-  if (!val) { await loadLimits(); return; }
+  if (!val) {
+    await loadLimits();
+    return;
+  }
   if (kind === 'cat') {
     const c = state.cats.find((x) => x.id === Number(id));
     await api.put(`/api/categories/${id}`, { ...c, name: val });
@@ -147,7 +151,7 @@ async function onLimitsClick(e) {
       return;
     }
     if (d.groupColor) {
-      const g = state.groups.find(x => x.id === Number(d.groupColor));
+      const g = state.groups.find((x) => x.id === Number(d.groupColor));
       await api.put(`/api/groups/${d.groupColor}`, { ...g, color: d.color });
       await loadLimits();
       return;
@@ -173,10 +177,12 @@ async function onLimitsClick(e) {
   }
 }
 
-export function renderCards(cards, stmtByCard, month) {
-  return cards.filter(c => c.active).map(c => {
-    const s = stmtByCard.get(c.id);
-    return `
+export function renderCards(cards, stmtByCard, _month) {
+  return cards
+    .filter((c) => c.active)
+    .map((c) => {
+      const s = stmtByCard.get(c.id);
+      return `
       <div class="paper-card" data-card="${c.id}">
         <div class="flex items-center justify-between">
           <span class="font-semibold">${esc(c.name)}</span>
@@ -190,29 +196,52 @@ export function renderCards(cards, stmtByCard, month) {
           <span class="ml-auto font-mono">${s ? `Bill ${formatBRL(s.amount_cents)}` : ''}</span>
         </div>
       </div>`;
-  }).join('');
+    })
+    .join('');
 }
 
 async function loadCards() {
   try {
     const cards = await api.get('/api/cards');
-    const active = cards.filter(c => c.active);
-    const stmts = await Promise.all(active.map(c =>
-      api.get(`/api/cards/${c.id}/statement?month=${$('month').value}`).then(s => [c.id, s])));
+    const active = cards.filter((c) => c.active);
+    const stmts = await Promise.all(
+      active.map((c) =>
+        api.get(`/api/cards/${c.id}/statement?month=${$('month').value}`).then((s) => [c.id, s]),
+      ),
+    );
     $('cards').innerHTML = renderCards(cards, new Map(stmts), $('month').value);
-    $('cards').querySelectorAll('button[data-del]').forEach(b =>
-      b.addEventListener('click', async () => { try { await api.del(`/api/cards/${b.dataset.del}`); loadCards(); } catch (e) { showError(e.message); } }));
-    const saveCfg = async id => {
+    $('cards')
+      .querySelectorAll('button[data-del]')
+      .forEach((b) => {
+        b.addEventListener('click', async () => {
+          try {
+            await api.del(`/api/cards/${b.dataset.del}`);
+            loadCards();
+          } catch (e) {
+            showError(e.message);
+          }
+        });
+      });
+    const saveCfg = async (id) => {
       const closing = $('cards').querySelector(`input[data-closing="${id}"]`).value;
       const due = $('cards').querySelector(`input[data-due="${id}"]`).value;
       try {
-        await api.put(`/api/cards/${id}/statement-config`,
-          { closing_day: closing ? Number(closing) : null, due_day: due ? Number(due) : null });
+        await api.put(`/api/cards/${id}/statement-config`, {
+          closing_day: closing ? Number(closing) : null,
+          due_day: due ? Number(due) : null,
+        });
         loadCards();
-      } catch (e) { showError(e.message); }
+      } catch (e) {
+        showError(e.message);
+      }
     };
-    $('cards').querySelectorAll('input[data-closing],input[data-due]').forEach(inp =>
-      inp.addEventListener('change', () => saveCfg(Number(inp.dataset.closing ?? inp.dataset.due))));
+    $('cards')
+      .querySelectorAll('input[data-closing],input[data-due]')
+      .forEach((inp) => {
+        inp.addEventListener('change', () =>
+          saveCfg(Number(inp.dataset.closing ?? inp.dataset.due)),
+        );
+      });
   } catch (e) {
     showError(e.message);
   }

--- a/public/js/settings.js
+++ b/public/js/settings.js
@@ -4,6 +4,7 @@ import {
   allocationStatus,
   allocationText,
   ceilingText,
+  nameEditor,
   renderGroupedLimitRows,
   renderLimitRows,
 } from './budget.js';
@@ -83,33 +84,44 @@ async function loadLimits() {
   }
 }
 
-async function renameCategory(id) {
-  const cat = state.cats.find((c) => c.id === id);
-  const name = prompt('Rename category', cat.name);
-  if (!name || name === cat.name) return;
-  await api.put(`/api/categories/${id}`, { ...cat, name });
-  await loadLimits();
+function beginRename(kind, id) {
+  const cell = $('limits').querySelector(`[data-name-cell="${kind}:${id}"]`);
+  if (!cell) return;
+  const cur = kind === 'cat'
+    ? state.cats.find((c) => c.id === id).name
+    : state.groups.find((g) => g.id === id).name;
+  cell.innerHTML = nameEditor(kind, id, cur);
+  cell.querySelector('input').focus();
 }
 
-async function renameGroup(id) {
-  const g = state.groups.find((x) => x.id === id);
-  const name = prompt('Rename group', g.name);
-  if (!name || name === g.name) return;
-  await api.put(`/api/groups/${id}`, { ...g, name });
-  await loadLimits();
+function beginAdd(kind, groupId) {
+  // For addcat: replace the "+ Add category" button cell content.
+  // For addgroup: replace the "+ Add group" button cell content.
+  const attr = kind === 'addcat' ? `data-add-cat="${groupId}"` : 'data-add-group';
+  const btn = $('limits').querySelector(`[${attr}]`);
+  if (!btn) return;
+  const cell = btn.closest('td');
+  if (!cell) return;
+  cell.innerHTML = nameEditor(kind, groupId, '');
+  cell.querySelector('input').focus();
 }
 
-async function addCategory(groupId) {
-  const name = prompt('New category name');
-  if (!name) return;
-  await api.post('/api/categories', { group_id: groupId, name });
-  await loadLimits();
-}
-
-async function addGroup() {
-  const name = prompt('New group name');
-  if (!name) return;
-  await api.post('/api/groups', { name });
+async function saveEdit(token) {
+  const [kind, rawId] = token.split(':');
+  const id = rawId;
+  const val = $('limits').querySelector(`[data-edit-input="${token}"]`).value.trim();
+  if (!val) { await loadLimits(); return; }
+  if (kind === 'cat') {
+    const c = state.cats.find((x) => x.id === Number(id));
+    await api.put(`/api/categories/${id}`, { ...c, name: val });
+  } else if (kind === 'group') {
+    const g = state.groups.find((x) => x.id === Number(id));
+    await api.put(`/api/groups/${id}`, { ...g, name: val });
+  } else if (kind === 'addcat') {
+    await api.post('/api/categories', { group_id: Number(id), name: val });
+  } else if (kind === 'addgroup') {
+    await api.post('/api/groups', { name: val });
+  }
   await loadLimits();
 }
 
@@ -127,11 +139,11 @@ async function onLimitsClick(e) {
       return;
     }
     if (d.catRename) {
-      await renameCategory(Number(d.catRename));
+      beginRename('cat', Number(d.catRename));
       return;
     }
     if (d.groupRename) {
-      await renameGroup(Number(d.groupRename));
+      beginRename('group', Number(d.groupRename));
       return;
     }
     if (d.groupColor) {
@@ -141,11 +153,19 @@ async function onLimitsClick(e) {
       return;
     }
     if (d.addCat) {
-      await addCategory(Number(d.addCat));
+      beginAdd('addcat', d.addCat);
       return;
     }
     if (e.target.hasAttribute('data-add-group')) {
-      await addGroup();
+      beginAdd('addgroup', 'new');
+      return;
+    }
+    if (d.save) {
+      await saveEdit(d.save);
+      return;
+    }
+    if (d.cancel) {
+      await loadLimits();
       return;
     }
   } catch (err) {

--- a/public/js/settings.js
+++ b/public/js/settings.js
@@ -13,7 +13,6 @@ import { currentMonth, esc, reaisToCents } from './format.js';
 // Re-exported so existing importers (and tests) can keep reaching them here.
 export { ceilingText, renderGroupedLimitRows, renderLimitRows };
 
-const COLORS = ['sage', 'gold', 'slate', 'neutral'];
 const $ = (id) => document.getElementById(id);
 const state = { groups: [], cats: [] };
 
@@ -100,18 +99,6 @@ async function renameGroup(id) {
   await loadLimits();
 }
 
-async function recolorGroup(id) {
-  const g = state.groups.find((x) => x.id === id);
-  const color = prompt(`Color (${COLORS.join(', ')})`, g.color);
-  if (!color || color === g.color) return;
-  if (!COLORS.includes(color)) {
-    showError(`Color must be one of: ${COLORS.join(', ')}`);
-    return;
-  }
-  await api.put(`/api/groups/${id}`, { ...g, color });
-  await loadLimits();
-}
-
 async function addCategory(groupId) {
   const name = prompt('New category name');
   if (!name) return;
@@ -147,8 +134,10 @@ async function onLimitsClick(e) {
       await renameGroup(Number(d.groupRename));
       return;
     }
-    if (d.groupRecolor) {
-      await recolorGroup(Number(d.groupRecolor));
+    if (d.groupColor) {
+      const g = state.groups.find(x => x.id === Number(d.groupColor));
+      await api.put(`/api/groups/${d.groupColor}`, { ...g, color: d.color });
+      await loadLimits();
       return;
     }
     if (d.addCat) {

--- a/public/js/settings.js
+++ b/public/js/settings.js
@@ -9,7 +9,7 @@ import {
   renderLimitRows,
 } from './budget.js';
 import { mountChrome } from './chrome.js';
-import { currentMonth, esc, reaisToCents } from './format.js';
+import { currentMonth, esc, formatBRL, reaisToCents } from './format.js';
 
 // Re-exported so existing importers (and tests) can keep reaching them here.
 export { ceilingText, renderGroupedLimitRows, renderLimitRows };
@@ -173,31 +173,46 @@ async function onLimitsClick(e) {
   }
 }
 
+export function renderCards(cards, stmtByCard, month) {
+  return cards.filter(c => c.active).map(c => {
+    const s = stmtByCard.get(c.id);
+    return `
+      <div class="paper-card" data-card="${c.id}">
+        <div class="flex items-center justify-between">
+          <span class="font-semibold">${esc(c.name)}</span>
+          <button data-del="${c.id}" class="text-clay text-sm">Remove</button>
+        </div>
+        <div class="mt-2 flex items-center gap-3 text-sm">
+          <label>Closing <input type="number" min="1" max="31" data-closing="${c.id}"
+            value="${c.closing_day ?? ''}" class="w-16 rounded border border-line px-1" /></label>
+          <label>Due <input type="number" min="1" max="31" data-due="${c.id}"
+            value="${c.due_day ?? ''}" class="w-16 rounded border border-line px-1" /></label>
+          <span class="ml-auto font-mono">${s ? `Bill ${formatBRL(s.amount_cents)}` : ''}</span>
+        </div>
+      </div>`;
+  }).join('');
+}
+
 async function loadCards() {
   try {
     const cards = await api.get('/api/cards');
-    $('cards').innerHTML = cards
-      .filter((c) => c.active)
-      .map(
-        (c) => `
-      <div class="flex items-center justify-between border-b border-line py-2">
-        <span>${esc(c.name)}</span>
-        <button data-del="${c.id}" class="text-clay text-sm">Remove</button>
-      </div>`,
-      )
-      .join('');
-    $('cards')
-      .querySelectorAll('button[data-del]')
-      .forEach((b) => {
-        b.addEventListener('click', async () => {
-          try {
-            await api.del(`/api/cards/${b.dataset.del}`);
-            loadCards();
-          } catch (e) {
-            showError(e.message);
-          }
-        });
-      });
+    const active = cards.filter(c => c.active);
+    const stmts = await Promise.all(active.map(c =>
+      api.get(`/api/cards/${c.id}/statement?month=${$('month').value}`).then(s => [c.id, s])));
+    $('cards').innerHTML = renderCards(cards, new Map(stmts), $('month').value);
+    $('cards').querySelectorAll('button[data-del]').forEach(b =>
+      b.addEventListener('click', async () => { try { await api.del(`/api/cards/${b.dataset.del}`); loadCards(); } catch (e) { showError(e.message); } }));
+    const saveCfg = async id => {
+      const closing = $('cards').querySelector(`input[data-closing="${id}"]`).value;
+      const due = $('cards').querySelector(`input[data-due="${id}"]`).value;
+      try {
+        await api.put(`/api/cards/${id}/statement-config`,
+          { closing_day: closing ? Number(closing) : null, due_day: due ? Number(due) : null });
+        loadCards();
+      } catch (e) { showError(e.message); }
+    };
+    $('cards').querySelectorAll('input[data-closing],input[data-due]').forEach(inp =>
+      inp.addEventListener('change', () => saveCfg(Number(inp.dataset.closing ?? inp.dataset.due))));
   } catch (e) {
     showError(e.message);
   }

--- a/public/js/transactions.js
+++ b/public/js/transactions.js
@@ -63,6 +63,12 @@ async function loadList() {
     if ($('filterCategory').value) qs.set('category_id', $('filterCategory').value);
     if ($('filterCard').value) qs.set('card_id', $('filterCard').value);
     if ($('search').value.trim()) qs.set('q', $('search').value.trim());
+    const csvQs = new URLSearchParams({ month: $('month').value });
+    if ($('filterCategory').value) csvQs.set('category_id', $('filterCategory').value);
+    if ($('filterCard').value) csvQs.set('card_id', $('filterCard').value);
+    if ($('search').value.trim()) csvQs.set('q', $('search').value.trim());
+    const exportLink = $('exportCsv');
+    if (exportLink) exportLink.href = `/api/transactions/export.csv?${csvQs}`;
     const { items: rows, total } = await getPage(`/api/transactions?${qs}`);
     const totalPages = Math.max(1, Math.ceil(total / perPage));
     if (page > totalPages) {

--- a/public/settings.html
+++ b/public/settings.html
@@ -13,7 +13,8 @@
   <main class="max-w-5xl mx-auto px-6 pt-2 space-y-6">
     <div class="flex items-center gap-3">
       <h1 class="font-display text-2xl">Settings</h1>
-      <input type="month" id="month" class="ml-auto rounded border border-line bg-card px-3 py-2" />
+      <a href="/api/backup" class="btn-ghost text-sm ml-auto">Download backup</a>
+      <input type="month" id="month" class="rounded border border-line bg-card px-3 py-2" />
     </div>
     <section class="paper-card">
       <h2 class="font-display text-xl mb-4">Savings model</h2>

--- a/public/transactions.html
+++ b/public/transactions.html
@@ -19,6 +19,7 @@
       <select id="filterCategory" class="rounded border border-line bg-card px-3 py-2"><option value="">All categories</option></select>
       <select id="filterCard" class="rounded border border-line bg-card px-3 py-2"><option value="">All cards</option></select>
       <input id="search" type="search" placeholder="Search description" class="rounded border border-line bg-card px-3 py-2" />
+      <a id="exportCsv" class="btn-ghost text-sm">Export CSV</a>
     </div>
     <div id="formCard">
       <form id="form" class="paper-card grid sm:grid-cols-2 lg:grid-cols-3 gap-3 mb-6">

--- a/src/adapters/http/controllers/backup.ts
+++ b/src/adapters/http/controllers/backup.ts
@@ -1,0 +1,12 @@
+import express from 'express';
+import type { Db } from '../../../infra/db';
+
+export function makeBackupController(db: Db): express.Router {
+  const router = express.Router();
+  router.get('/', (_req, res) => {
+    const buf = db.serialize();
+    const stamp = new Date().toISOString().slice(0, 10);
+    res.attachment(`gastando-backup-${stamp}.db`).type('application/octet-stream').send(buf);
+  });
+  return router;
+}

--- a/src/adapters/http/controllers/cards.ts
+++ b/src/adapters/http/controllers/cards.ts
@@ -18,13 +18,19 @@ export function makeCardsController(uc: CardUseCases): express.Router {
 
   router.get('/:id/statement', (req, res) => {
     const q = req.query.month;
-    const month = (typeof q === 'string' && MONTH_RE.test(q)) ? q : new Date().toISOString().slice(0, 7);
+    const month =
+      typeof q === 'string' && MONTH_RE.test(q) ? q : new Date().toISOString().slice(0, 7);
     res.json(uc.statement(Number(req.params.id), month));
   });
 
   router.put('/:id/statement-config', (req, res) => {
     const body = parse(statementConfigSchema, req.body);
-    res.json(uc.setConfig(Number(req.params.id), { closing_day: body.closing_day ?? null, due_day: body.due_day ?? null }));
+    res.json(
+      uc.setConfig(Number(req.params.id), {
+        closing_day: body.closing_day ?? null,
+        due_day: body.due_day ?? null,
+      }),
+    );
   });
 
   router.put('/:id', (req, res) => {

--- a/src/adapters/http/controllers/cards.ts
+++ b/src/adapters/http/controllers/cards.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import type { makeCardUseCases } from '../../../application/use-cases/cards';
-import { nameBodySchema } from '../schemas/common';
+import { statementConfigSchema } from '../schemas/cards';
+import { MONTH_RE, nameBodySchema } from '../schemas/common';
 import { parse } from '../validate';
 
 type CardUseCases = ReturnType<typeof makeCardUseCases>;
@@ -13,6 +14,17 @@ export function makeCardsController(uc: CardUseCases): express.Router {
   router.post('/', (req, res) => {
     parse(nameBodySchema, req.body);
     res.status(201).json(uc.create(req.body));
+  });
+
+  router.get('/:id/statement', (req, res) => {
+    const q = req.query.month;
+    const month = (typeof q === 'string' && MONTH_RE.test(q)) ? q : new Date().toISOString().slice(0, 7);
+    res.json(uc.statement(Number(req.params.id), month));
+  });
+
+  router.put('/:id/statement-config', (req, res) => {
+    const body = parse(statementConfigSchema, req.body);
+    res.json(uc.setConfig(Number(req.params.id), { closing_day: body.closing_day ?? null, due_day: body.due_day ?? null }));
   });
 
   router.put('/:id', (req, res) => {

--- a/src/adapters/http/controllers/transactions.ts
+++ b/src/adapters/http/controllers/transactions.ts
@@ -51,6 +51,15 @@ export function makeTransactionsController(uc: TransactionUseCases): express.Rou
     res.status(201).json(uc.create(req.body));
   });
 
+  router.get('/export.csv', (req, res) => {
+    const filter: Record<string, unknown> = {};
+    if (req.query.month !== undefined) filter.month = String(req.query.month);
+    if (req.query.category_id !== undefined) filter.categoryId = Number(req.query.category_id);
+    if (req.query.card_id !== undefined) filter.cardId = Number(req.query.card_id);
+    if (req.query.q !== undefined) filter.q = String(req.query.q);
+    res.attachment('transactions.csv').type('text/csv').send(uc.exportCsv(filter));
+  });
+
   router.put('/:id', (req, res) => {
     parse(updateTransactionSchema, req.body);
     res.json(uc.update(Number(req.params.id), req.body));

--- a/src/adapters/http/schemas/cards.ts
+++ b/src/adapters/http/schemas/cards.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+const dayOrNull = z.custom<number | null>(
+  v => v === null || v === undefined || (typeof v === 'number' && Number.isInteger(v) && v >= 1 && v <= 31),
+  { message: 'day must be an integer 1..31 or null' });
+
+export const statementConfigSchema = z.object({ closing_day: dayOrNull, due_day: dayOrNull });

--- a/src/adapters/http/schemas/cards.ts
+++ b/src/adapters/http/schemas/cards.ts
@@ -1,7 +1,11 @@
 import { z } from 'zod';
 
 const dayOrNull = z.custom<number | null>(
-  v => v === null || v === undefined || (typeof v === 'number' && Number.isInteger(v) && v >= 1 && v <= 31),
-  { message: 'day must be an integer 1..31 or null' });
+  (v) =>
+    v === null ||
+    v === undefined ||
+    (typeof v === 'number' && Number.isInteger(v) && v >= 1 && v <= 31),
+  { message: 'day must be an integer 1..31 or null' },
+);
 
 export const statementConfigSchema = z.object({ closing_day: dayOrNull, due_day: dayOrNull });

--- a/src/app.ts
+++ b/src/app.ts
@@ -30,6 +30,7 @@ export function createApp(arg: Container | Db): express.Express {
   app.use('/api/bi', controllers.bi);
   app.use('/api/simulate', controllers.simulate);
   app.use('/api/recurring', controllers.recurring);
+  app.use('/api/backup', controllers.backup);
 
   app.use(express.static(path.join(__dirname, '..', 'public')));
   app.use(errorHandler);

--- a/src/application/use-cases/cards.ts
+++ b/src/application/use-cases/cards.ts
@@ -1,9 +1,12 @@
 import type { Card } from '../../domain/entities';
-import type { CardRepository, ReportRepository } from '../../domain/ports';
 import { AppError } from '../../domain/errors';
+import type { CardRepository, ReportRepository } from '../../domain/ports';
 import { addMonths, chargeDate } from '../../domain/services/dates';
 
-export interface CardUseCaseDeps { cards: CardRepository; reports: ReportRepository; }
+export interface CardUseCaseDeps {
+  cards: CardRepository;
+  reports: ReportRepository;
+}
 
 export interface CreateCardInput {
   name: string;
@@ -44,15 +47,25 @@ export function makeCardUseCases(deps: CardUseCaseDeps) {
       if (card.closing_day == null) {
         // No cycle configured: fall back to the calendar month window.
         const start = chargeDate(addMonths(month, -1), 31); // last day of prev month, exclusive
-        const end = chargeDate(month, 31);                  // last day of this month, inclusive
-        return { card_id: id, month, closing_date: null, due_date: null,
-          amount_cents: reports.spendByCardDateRange(id, start, end) };
+        const end = chargeDate(month, 31); // last day of this month, inclusive
+        return {
+          card_id: id,
+          month,
+          closing_date: null,
+          due_date: null,
+          amount_cents: reports.spendByCardDateRange(id, start, end),
+        };
       }
       const closing_date = chargeDate(month, card.closing_day);
       const start = chargeDate(addMonths(month, -1), card.closing_day);
       const due_date = card.due_day != null ? chargeDate(month, card.due_day) : null;
-      return { card_id: id, month, closing_date, due_date,
-        amount_cents: reports.spendByCardDateRange(id, start, closing_date) };
+      return {
+        card_id: id,
+        month,
+        closing_date,
+        due_date,
+        amount_cents: reports.spendByCardDateRange(id, start, closing_date),
+      };
     },
   };
 }

--- a/src/application/use-cases/cards.ts
+++ b/src/application/use-cases/cards.ts
@@ -1,10 +1,9 @@
 import type { Card } from '../../domain/entities';
+import type { CardRepository, ReportRepository } from '../../domain/ports';
 import { AppError } from '../../domain/errors';
-import type { CardRepository } from '../../domain/ports';
+import { addMonths, chargeDate } from '../../domain/services/dates';
 
-export interface CardUseCaseDeps {
-  cards: CardRepository;
-}
+export interface CardUseCaseDeps { cards: CardRepository; reports: ReportRepository; }
 
 export interface CreateCardInput {
   name: string;
@@ -15,7 +14,7 @@ export interface UpdateCardInput {
 }
 
 export function makeCardUseCases(deps: CardUseCaseDeps) {
-  const { cards } = deps;
+  const { cards, reports } = deps;
   return {
     list(): Card[] {
       return cards.listAll();
@@ -31,6 +30,29 @@ export function makeCardUseCases(deps: CardUseCaseDeps) {
     },
     remove(id: number): void {
       if (cards.deactivate(id) === 0) throw new AppError(404, 'card not found');
+    },
+    setConfig(id: number, body: { closing_day: number | null; due_day: number | null }): Card {
+      if (cards.setStatementConfig(id, body.closing_day, body.due_day) === 0) {
+        throw new AppError(404, 'card not found');
+      }
+      return cards.findById(id) as Card;
+    },
+
+    statement(id: number, month: string) {
+      const card = cards.findById(id);
+      if (!card) throw new AppError(404, 'card not found');
+      if (card.closing_day == null) {
+        // No cycle configured: fall back to the calendar month window.
+        const start = chargeDate(addMonths(month, -1), 31); // last day of prev month, exclusive
+        const end = chargeDate(month, 31);                  // last day of this month, inclusive
+        return { card_id: id, month, closing_date: null, due_date: null,
+          amount_cents: reports.spendByCardDateRange(id, start, end) };
+      }
+      const closing_date = chargeDate(month, card.closing_day);
+      const start = chargeDate(addMonths(month, -1), card.closing_day);
+      const due_date = card.due_day != null ? chargeDate(month, card.due_day) : null;
+      return { card_id: id, month, closing_date, due_date,
+        amount_cents: reports.spendByCardDateRange(id, start, closing_date) };
     },
   };
 }

--- a/src/application/use-cases/transactions.ts
+++ b/src/application/use-cases/transactions.ts
@@ -100,19 +100,41 @@ export function makeTransactionUseCases(deps: TransactionUseCaseDeps) {
       if (transactions.remove(id) === 0) throw new AppError(404, 'transaction not found');
     },
 
-    exportCsv(filter: { month?: string; categoryId?: number; cardId?: number; q?: string }): string {
+    exportCsv(filter: {
+      month?: string;
+      categoryId?: number;
+      cardId?: number;
+      q?: string;
+    }): string {
       const items = transactions.list({ ...filter, limit: null, offset: 0 });
-      const catName = new Map(categories.listAll().map(c => [c.id, c.name]));
-      const cardName = new Map(cards.listAll().map(c => [c.id, c.name]));
+      const catName = new Map(categories.listAll().map((c) => [c.id, c.name]));
+      const cardName = new Map(cards.listAll().map((c) => [c.id, c.name]));
       const cell = (v: unknown) => {
         const s = String(v ?? '');
         return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
       };
-      const header = ['date', 'category', 'card', 'amount_cents', 'description', 'installment_no', 'installment_total'];
-      const rows = items.map(t => [
-        t.date, catName.get(t.category_id) ?? '', cardName.get(t.card_id) ?? '',
-        t.amount_cents, t.description, t.installment_no ?? '', t.installment_total ?? '',
-      ].map(cell).join(','));
+      const header = [
+        'date',
+        'category',
+        'card',
+        'amount_cents',
+        'description',
+        'installment_no',
+        'installment_total',
+      ];
+      const rows = items.map((t) =>
+        [
+          t.date,
+          catName.get(t.category_id) ?? '',
+          cardName.get(t.card_id) ?? '',
+          t.amount_cents,
+          t.description,
+          t.installment_no ?? '',
+          t.installment_total ?? '',
+        ]
+          .map(cell)
+          .join(','),
+      );
       return [header.join(','), ...rows].join('\n');
     },
   };

--- a/src/application/use-cases/transactions.ts
+++ b/src/application/use-cases/transactions.ts
@@ -99,5 +99,21 @@ export function makeTransactionUseCases(deps: TransactionUseCaseDeps) {
     remove(id: number): void {
       if (transactions.remove(id) === 0) throw new AppError(404, 'transaction not found');
     },
+
+    exportCsv(filter: { month?: string; categoryId?: number; cardId?: number; q?: string }): string {
+      const items = transactions.list({ ...filter, limit: null, offset: 0 });
+      const catName = new Map(categories.listAll().map(c => [c.id, c.name]));
+      const cardName = new Map(cards.listAll().map(c => [c.id, c.name]));
+      const cell = (v: unknown) => {
+        const s = String(v ?? '');
+        return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+      };
+      const header = ['date', 'category', 'card', 'amount_cents', 'description', 'installment_no', 'installment_total'];
+      const rows = items.map(t => [
+        t.date, catName.get(t.category_id) ?? '', cardName.get(t.card_id) ?? '',
+        t.amount_cents, t.description, t.installment_no ?? '', t.installment_total ?? '',
+      ].map(cell).join(','));
+      return [header.join(','), ...rows].join('\n');
+    },
   };
 }

--- a/src/domain/entities/index.ts
+++ b/src/domain/entities/index.ts
@@ -17,6 +17,8 @@ export interface Card {
   id: number;
   name: string;
   active: number;
+  closing_day: number | null;
+  due_day: number | null;
 }
 export interface CategoryLimit {
   id: number;

--- a/src/domain/ports/index.ts
+++ b/src/domain/ports/index.ts
@@ -39,6 +39,7 @@ export interface CardRepository {
   insert(c: { name: string }): Card;
   update(id: number, c: { name: string; active: number }): number;
   deactivate(id: number): number;
+  setStatementConfig(id: number, closingDay: number | null, dueDay: number | null): number;
 }
 
 export interface TransactionFilter {

--- a/src/domain/ports/index.ts
+++ b/src/domain/ports/index.ts
@@ -164,4 +164,5 @@ export interface ReportRepository {
   dashboardCategories(): Array<
     Category & { group_name: string; group_color: string; group_sort: number }
   >;
+  spendByCardDateRange(cardId: number, startExclusive: string, endInclusive: string): number;
 }

--- a/src/infra/composition.ts
+++ b/src/infra/composition.ts
@@ -84,7 +84,7 @@ export function buildContainer(db: Db): Container {
       groups: repositories.groups,
     }),
     groups: makeGroupUseCases({ groups: repositories.groups }),
-    cards: makeCardUseCases({ cards: repositories.cards }),
+    cards: makeCardUseCases({ cards: repositories.cards, reports: repositories.reports }),
     limits: makeLimitUseCases({
       limits: repositories.limits,
       categories: repositories.categories,

--- a/src/infra/composition.ts
+++ b/src/infra/composition.ts
@@ -1,4 +1,5 @@
 import type express from 'express';
+import { makeBackupController } from '../adapters/http/controllers/backup';
 import { makeBiController } from '../adapters/http/controllers/bi';
 import { makeCardsController } from '../adapters/http/controllers/cards';
 import { makeCategoriesController } from '../adapters/http/controllers/categories';
@@ -49,6 +50,7 @@ export interface Container {
     bi: express.Router;
     simulate: express.Router;
     recurring: express.Router;
+    backup: express.Router;
   };
 }
 
@@ -127,6 +129,7 @@ export function buildContainer(db: Db): Container {
     bi: makeBiController(useCases.bi),
     simulate: makeSimulateController(useCases.simulate),
     recurring: makeRecurringController(useCases.recurring),
+    backup: makeBackupController(db),
   };
 
   return { db, controllers };

--- a/src/infra/repositories/cards.ts
+++ b/src/infra/repositories/cards.ts
@@ -21,5 +21,9 @@ export function makeCardRepository(db: Db): CardRepository {
     deactivate(id: number): number {
       return db.prepare('UPDATE cards SET active=0 WHERE id=?').run(id).changes;
     },
+    setStatementConfig(id, closingDay, dueDay): number {
+      return db.prepare('UPDATE cards SET closing_day=?, due_day=? WHERE id=?')
+        .run(closingDay, dueDay, id).changes;
+    },
   };
 }

--- a/src/infra/repositories/cards.ts
+++ b/src/infra/repositories/cards.ts
@@ -22,7 +22,8 @@ export function makeCardRepository(db: Db): CardRepository {
       return db.prepare('UPDATE cards SET active=0 WHERE id=?').run(id).changes;
     },
     setStatementConfig(id, closingDay, dueDay): number {
-      return db.prepare('UPDATE cards SET closing_day=?, due_day=? WHERE id=?')
+      return db
+        .prepare('UPDATE cards SET closing_day=?, due_day=? WHERE id=?')
         .run(closingDay, dueDay, id).changes;
     },
   };

--- a/src/infra/repositories/reports.ts
+++ b/src/infra/repositories/reports.ts
@@ -70,10 +70,14 @@ export function makeReportRepository(db: Db): ReportRepository {
         .all() as DashboardCategoryRow[];
     },
     spendByCardDateRange(cardId: number, startExclusive: string, endInclusive: string): number {
-      return (db.prepare(
-        `SELECT COALESCE(SUM(amount_cents),0) AS s FROM transactions
+      return (
+        db
+          .prepare(
+            `SELECT COALESCE(SUM(amount_cents),0) AS s FROM transactions
          WHERE card_id=? AND date > ? AND date <= ?`,
-      ).get(cardId, startExclusive, endInclusive) as { s: number }).s;
+          )
+          .get(cardId, startExclusive, endInclusive) as { s: number }
+      ).s;
     },
   };
 }

--- a/src/infra/repositories/reports.ts
+++ b/src/infra/repositories/reports.ts
@@ -69,5 +69,11 @@ export function makeReportRepository(db: Db): ReportRepository {
         )
         .all() as DashboardCategoryRow[];
     },
+    spendByCardDateRange(cardId: number, startExclusive: string, endInclusive: string): number {
+      return (db.prepare(
+        `SELECT COALESCE(SUM(amount_cents),0) AS s FROM transactions
+         WHERE card_id=? AND date > ? AND date <= ?`,
+      ).get(cardId, startExclusive, endInclusive) as { s: number }).s;
+    },
   };
 }

--- a/test/backup.test.ts
+++ b/test/backup.test.ts
@@ -1,0 +1,14 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const request = require('supertest');
+const { makeTestDb } = require('./helpers');
+const { createApp } = require('../src/app');
+
+test('GET /api/backup streams a SQLite file', async () => {
+  const ctx = makeTestDb();
+  const app = createApp(ctx.db);
+  const res = await request(app).get('/api/backup').expect(200);
+  assert.match(res.headers['content-disposition'], /attachment/);
+  // SQLite files start with the "SQLite format 3\0" magic header.
+  assert.match(res.body.slice(0, 15).toString('utf8'), /SQLite format 3/);
+});

--- a/test/budget.test.ts
+++ b/test/budget.test.ts
@@ -63,3 +63,16 @@ test('colorSwatches renders a button per palette color and marks the current', a
   assert.match(html, /data-group-color="3"/);
   assert.match(html, /data-color="gold"[^>]*ring/); // current is highlighted
 });
+
+test('nameEditor renders an input prefilled with the current value', async () => {
+  const { nameEditor } = await import('../public/js/budget.js');
+  const html = nameEditor('cat', 5, 'Mercado');
+  assert.match(html, /data-save="cat:5"/);
+  assert.match(html, /data-cancel="cat:5"/);
+  assert.match(html, /value="Mercado"/);
+});
+
+test('nameEditor escapes the value', async () => {
+  const { nameEditor } = await import('../public/js/budget.js');
+  assert.doesNotMatch(nameEditor('group', 1, '"<x>'), /<x>/);
+});

--- a/test/budget.test.ts
+++ b/test/budget.test.ts
@@ -55,3 +55,11 @@ test('allocationPillClass flips between ok and over across the boundary', async 
   assert.equal(allocationPillClass(within), 'pill pill-ok');
   assert.equal(allocationPillClass(over), 'pill pill-over');
 });
+
+test('colorSwatches renders a button per palette color and marks the current', async () => {
+  const { colorSwatches, GROUP_COLORS } = await import('../public/js/budget.js');
+  const html = colorSwatches(3, 'gold');
+  for (const c of GROUP_COLORS) assert.match(html, new RegExp(`data-color="${c}"`));
+  assert.match(html, /data-group-color="3"/);
+  assert.match(html, /data-color="gold"[^>]*ring/); // current is highlighted
+});

--- a/test/cardStatement.test.ts
+++ b/test/cardStatement.test.ts
@@ -17,13 +17,27 @@ test('setStatementConfig persists closing/due day', () => {
 test('card statement sums the closing-day cycle', async () => {
   const ctx = makeTestDb();
   const app = createApp(ctx.db);
-  await request(app).put(`/api/cards/${ctx.cardId}/statement-config`).send({ closing_day: 20, due_day: 27 }).expect(200);
-  const add = date => request(app).post('/api/transactions')
-    .send({ date, category_id: ctx.categoryId, card_id: ctx.cardId, amount_cents: 10000, description: 'x' }).expect(201);
+  await request(app)
+    .put(`/api/cards/${ctx.cardId}/statement-config`)
+    .send({ closing_day: 20, due_day: 27 })
+    .expect(200);
+  const add = (date) =>
+    request(app)
+      .post('/api/transactions')
+      .send({
+        date,
+        category_id: ctx.categoryId,
+        card_id: ctx.cardId,
+        amount_cents: 10000,
+        description: 'x',
+      })
+      .expect(201);
   await add('2026-05-25'); // after May 20 close -> belongs to June statement
   await add('2026-06-10'); // before June 20 close -> June statement
   await add('2026-06-25'); // after June 20 close -> July statement, excluded
-  const res = await request(app).get(`/api/cards/${ctx.cardId}/statement?month=2026-06`).expect(200);
+  const res = await request(app)
+    .get(`/api/cards/${ctx.cardId}/statement?month=2026-06`)
+    .expect(200);
   assert.equal(res.body.amount_cents, 20000);
   assert.equal(res.body.closing_date, '2026-06-20');
   assert.equal(res.body.due_date, '2026-06-27');

--- a/test/cardStatement.test.ts
+++ b/test/cardStatement.test.ts
@@ -2,6 +2,8 @@ const { test } = require('node:test');
 const assert = require('node:assert');
 const { makeTestDb } = require('./helpers');
 const { makeCardRepository } = require('../src/infra/repositories/cards');
+const request = require('supertest');
+const { createApp } = require('../src/app');
 
 test('setStatementConfig persists closing/due day', () => {
   const ctx = makeTestDb();
@@ -10,4 +12,19 @@ test('setStatementConfig persists closing/due day', () => {
   const card = repo.findById(ctx.cardId);
   assert.equal(card.closing_day, 20);
   assert.equal(card.due_day, 27);
+});
+
+test('card statement sums the closing-day cycle', async () => {
+  const ctx = makeTestDb();
+  const app = createApp(ctx.db);
+  await request(app).put(`/api/cards/${ctx.cardId}/statement-config`).send({ closing_day: 20, due_day: 27 }).expect(200);
+  const add = date => request(app).post('/api/transactions')
+    .send({ date, category_id: ctx.categoryId, card_id: ctx.cardId, amount_cents: 10000, description: 'x' }).expect(201);
+  await add('2026-05-25'); // after May 20 close -> belongs to June statement
+  await add('2026-06-10'); // before June 20 close -> June statement
+  await add('2026-06-25'); // after June 20 close -> July statement, excluded
+  const res = await request(app).get(`/api/cards/${ctx.cardId}/statement?month=2026-06`).expect(200);
+  assert.equal(res.body.amount_cents, 20000);
+  assert.equal(res.body.closing_date, '2026-06-20');
+  assert.equal(res.body.due_date, '2026-06-27');
 });

--- a/test/cardStatement.test.ts
+++ b/test/cardStatement.test.ts
@@ -1,0 +1,13 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { makeTestDb } = require('./helpers');
+const { makeCardRepository } = require('../src/infra/repositories/cards');
+
+test('setStatementConfig persists closing/due day', () => {
+  const ctx = makeTestDb();
+  const repo = makeCardRepository(ctx.db);
+  assert.equal(repo.setStatementConfig(ctx.cardId, 20, 27), 1);
+  const card = repo.findById(ctx.cardId);
+  assert.equal(card.closing_day, 20);
+  assert.equal(card.due_day, 27);
+});

--- a/test/settingsRender.test.ts
+++ b/test/settingsRender.test.ts
@@ -42,3 +42,14 @@ test('renderGroupedLimitRows escapes HTML in names', async () => {
   assert.ok(html.includes('&lt;img src=x'), 'expected escaped category name');
   assert.ok(html.includes('&lt;b&gt;G&lt;/b&gt;'), 'expected escaped group name');
 });
+
+test('renderCards shows the projected bill and config inputs', async () => {
+  const { renderCards } = await import('../public/js/settings.js');
+  const cards = [{ id: 2, name: 'Nubank', active: 1, closing_day: 20, due_day: 27 }];
+  const stmt = new Map([[2, { amount_cents: 35000, closing_date: '2026-06-20', due_date: '2026-06-27' }]]);
+  const html = renderCards(cards, stmt, '2026-06');
+  assert.match(html, /Nubank/);
+  assert.match(html, /R\$ 350,00/);          // projected bill
+  assert.match(html, /data-closing="2"/);
+  assert.match(html, /value="20"/);
+});

--- a/test/settingsRender.test.ts
+++ b/test/settingsRender.test.ts
@@ -46,10 +46,12 @@ test('renderGroupedLimitRows escapes HTML in names', async () => {
 test('renderCards shows the projected bill and config inputs', async () => {
   const { renderCards } = await import('../public/js/settings.js');
   const cards = [{ id: 2, name: 'Nubank', active: 1, closing_day: 20, due_day: 27 }];
-  const stmt = new Map([[2, { amount_cents: 35000, closing_date: '2026-06-20', due_date: '2026-06-27' }]]);
+  const stmt = new Map([
+    [2, { amount_cents: 35000, closing_date: '2026-06-20', due_date: '2026-06-27' }],
+  ]);
   const html = renderCards(cards, stmt, '2026-06');
   assert.match(html, /Nubank/);
-  assert.match(html, /R\$ 350,00/);          // projected bill
+  assert.match(html, /R\$ 350,00/); // projected bill
   assert.match(html, /data-closing="2"/);
   assert.match(html, /value="20"/);
 });

--- a/test/settingsRender.test.ts
+++ b/test/settingsRender.test.ts
@@ -30,7 +30,7 @@ test('renderGroupedLimitRows groups categories under their group with controls',
   assert.match(html, /data-add-group/);
   assert.match(html, /data-cat-rename="1"/);
   assert.match(html, /data-group-rename="7"/);
-  assert.match(html, /data-group-recolor="7"/);
+  assert.match(html, /data-group-color="7"/);
 });
 
 test('renderGroupedLimitRows escapes HTML in names', async () => {

--- a/test/transactions.test.ts
+++ b/test/transactions.test.ts
@@ -124,3 +124,15 @@ test('GET /api/transactions filters by description q', async () => {
   assert.equal(res.body.length, 1);
   assert.match(res.body[0].description, /Coffee/);
 });
+
+test('GET /api/transactions/export.csv returns a CSV with a header and rows', async () => {
+  const ctx = makeTestDb();
+  const app = createApp(ctx.db);
+  await request(app).post('/api/transactions').send({ date: '2026-06-01', category_id: ctx.categoryId,
+    card_id: ctx.cardId, amount_cents: 1234, description: 'Coffee, hot' }).expect(201);
+  const res = await request(app).get('/api/transactions/export.csv').expect(200);
+  assert.match(res.headers['content-type'], /text\/csv/);
+  assert.match(res.text, /date,category,card,amount_cents,description/);
+  assert.match(res.text, /Supermercado/);
+  assert.match(res.text, /"Coffee, hot"/); // comma-containing field is quoted
+});

--- a/test/transactions.test.ts
+++ b/test/transactions.test.ts
@@ -128,8 +128,16 @@ test('GET /api/transactions filters by description q', async () => {
 test('GET /api/transactions/export.csv returns a CSV with a header and rows', async () => {
   const ctx = makeTestDb();
   const app = createApp(ctx.db);
-  await request(app).post('/api/transactions').send({ date: '2026-06-01', category_id: ctx.categoryId,
-    card_id: ctx.cardId, amount_cents: 1234, description: 'Coffee, hot' }).expect(201);
+  await request(app)
+    .post('/api/transactions')
+    .send({
+      date: '2026-06-01',
+      category_id: ctx.categoryId,
+      card_id: ctx.cardId,
+      amount_cents: 1234,
+      description: 'Coffee, hot',
+    })
+    .expect(201);
   const res = await request(app).get('/api/transactions/export.csv').expect(200);
   assert.match(res.headers['content-type'], /text\/csv/);
   assert.match(res.text, /date,category,card,amount_cents,description/);


### PR DESCRIPTION
## Phase 4 — Polish & Bigger Bets

Replaces raw browser `prompt()`/`confirm()` in Settings with inline editing + color swatches; adds CSV export and an in-app SQLite backup download; and adds per-card closing/due days with a "projected bill" statement view.

Implemented task-by-task with TDD (subagent-driven development). Each task was individually reviewed; the whole branch then passed a final review with a **Ready to merge: Yes** verdict. Rebased onto `main` (on top of the merged Phase 3, #16) so the diff is Phase 4 only.

### What's included
- **Settings UX (no more browser prompts):**
  - Color swatches replace the recolor `prompt()` (`colorSwatches` in `budget.js`).
  - Inline rename/add replace the remaining `prompt()`s (`nameEditor`, escaped, `kind:id` save/cancel routing).
- **CSV export:** `TransactionUseCases.exportCsv` (RFC 4180 quoting, unpaginated) + `GET /api/transactions/export.csv`, with an Export CSV link that mirrors the current filters.
- **SQLite backup:** `GET /api/backup` streams `db.serialize()` as an attachment; Download-backup link in Settings; README documents restore (stop app, swap `data/gastando.db`).
- **Per-card statement (the on-theme feature):**
  - Migration `005` adds nullable `cards.closing_day` / `cards.due_day`.
  - `ReportRepository.spendByCardDateRange` + `CardUseCases.statement`/`setConfig`: statement window `( chargeDate(M-1,c), chargeDate(M,c) ]`, with a calendar-month fallback when `closing_day` is null.
  - `GET /api/cards/:id/statement?month=` and `PUT /api/cards/:id/statement-config`.
  - Settings UI: `renderCards` shows the projected bill + closing/due-day config inputs.

### Verification
- 149/149 tests pass; `tsc --noEmit` clean; Biome lint clean (108 files); coverage 89.29% statements / 82.26% branches / 98.86% functions (all ≥80%).

### Deferred tech-debt (non-blocking, from final review)
- CSV formula-injection guard (prefix cells starting with `= + - @`); low risk for a single-user local app.
- `export.csv` doesn't 400 on a malformed `month` the way `GET /api/transactions` does — a shared validated-filter helper would align them.
- Add tests for the null-`closing_day` statement fallback and the 404 paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
